### PR TITLE
Add ng, perng, parng, and mapcoeffs to Dipy MAPMRI outputs

### DIFF
--- a/qsirecon/interfaces/dipy.py
+++ b/qsirecon/interfaces/dipy.py
@@ -291,17 +291,18 @@ class MAPMRIReconstruction(DipyReconInterface):
         rtpp = mapfit_aniso.rtpp()
         self._results["rtpp"] = self._save_scalar(rtpp, "_rtpp", runtime, dwi_img)
 
-        ng = mapfit_aniso.ng()
-        self._results["ng"] = self._save_scalar(ng, "_ng", runtime, dwi_img)
-
-        perng = mapfit_aniso.perng()
-        self._results["perng"] = self._save_scalar(perng, "_perng", runtime, dwi_img)
-
-        parng = mapfit_aniso.parng()
-        self._results["parng"] = self._save_scalar(parng, "_parng", runtime, dwi_img)
-
         coeffs = mapfit_aniso.mapmri_coeff
         self._results["mapmri_coeffs"] = self._save_scalar(coeffs, "_mapcoeffs", runtime, dwi_img)
+
+        if not self.inputs.anisotropic_scaling:
+            ng = mapfit_aniso.ng()
+            self._results["ng"] = self._save_scalar(ng, "_ng", runtime, dwi_img)
+
+            perng = mapfit_aniso.perng()
+            self._results["perng"] = self._save_scalar(perng, "_perng", runtime, dwi_img)
+
+            parng = mapfit_aniso.parng()
+            self._results["parng"] = self._save_scalar(parng, "_parng", runtime, dwi_img)
 
         # Write DSI Studio or MRtrix
         self._write_external_formats(runtime, mapfit_aniso, mask_img, "_MAPMRI")

--- a/qsirecon/interfaces/dipy.py
+++ b/qsirecon/interfaces/dipy.py
@@ -294,14 +294,14 @@ class MAPMRIReconstruction(DipyReconInterface):
         coeffs = mapfit_aniso.mapmri_coeff
         self._results["mapmri_coeffs"] = self._save_scalar(coeffs, "_mapcoeffs", runtime, dwi_img)
 
-        if not self.inputs.anisotropic_scaling:
+        if self.inputs.anisotropic_scaling:
             ng = mapfit_aniso.ng()
             self._results["ng"] = self._save_scalar(ng, "_ng", runtime, dwi_img)
 
-            perng = mapfit_aniso.perng()
+            perng = mapfit_aniso.ng_perpendicular()
             self._results["perng"] = self._save_scalar(perng, "_perng", runtime, dwi_img)
 
-            parng = mapfit_aniso.parng()
+            parng = mapfit_aniso.ng_parallel()
             self._results["parng"] = self._save_scalar(parng, "_parng", runtime, dwi_img)
 
         # Write DSI Studio or MRtrix

--- a/qsirecon/interfaces/dipy.py
+++ b/qsirecon/interfaces/dipy.py
@@ -291,6 +291,15 @@ class MAPMRIReconstruction(DipyReconInterface):
         rtpp = mapfit_aniso.rtpp()
         self._results["rtpp"] = self._save_scalar(rtpp, "_rtpp", runtime, dwi_img)
 
+        ng = mapfit_aniso.ng()
+        self._results["ng"] = self._save_scalar(ng, "_ng", runtime, dwi_img)
+
+        perng = mapfit_aniso.perng()
+        self._results["perng"] = self._save_scalar(perng, "_perng", runtime, dwi_img)
+
+        parng = mapfit_aniso.parng()
+        self._results["parng"] = self._save_scalar(parng, "_parng", runtime, dwi_img)
+
         coeffs = mapfit_aniso.mapmri_coeff
         self._results["mapmri_coeffs"] = self._save_scalar(coeffs, "_mapcoeffs", runtime, dwi_img)
 

--- a/qsirecon/interfaces/recon_scalars.py
+++ b/qsirecon/interfaces/recon_scalars.py
@@ -369,6 +369,10 @@ dipy_mapmri_scalars = {
         "desc": "Non-Gaussianity perpendicular from MAPMRI",
         "bids": {"mdp": "NGperp", "model": "mapmri"},
     },
+    "mapcoeffs_file": {
+        "desc": "MAPMRI coefficients",
+        "bids": {"mdp": "mapcoeffs", "model": "mapmri"},
+    },
 }
 
 

--- a/qsirecon/tests/data/dipy_mapmri_outputs.txt
+++ b/qsirecon/tests/data/dipy_mapmri_outputs.txt
@@ -20,6 +20,7 @@ qsirecon-mapmri_recon
 qsirecon-mapmri_recon/sub-ABCD
 qsirecon-mapmri_recon/sub-ABCD/dwi
 qsirecon-mapmri_recon/sub-ABCD/dwi/sub-ABCD_acq-10per000_space-T1w_desc-preproc_model-mapmri_mdp-MSD_dwimap.nii.gz
+qsirecon-mapmri_recon/sub-ABCD/dwi/sub-ABCD_acq-10per000_space-T1w_desc-preproc_model-mapmri_mdp-mapcoeffs_dwimap.nii.gz
 qsirecon-mapmri_recon/sub-ABCD/dwi/sub-ABCD_acq-10per000_space-T1w_desc-preproc_model-mapmri_mdp-QIV_dwimap.nii.gz
 qsirecon-mapmri_recon/sub-ABCD/dwi/sub-ABCD_acq-10per000_space-T1w_desc-preproc_model-mapmri_mdp-RTAP_dwimap.nii.gz
 qsirecon-mapmri_recon/sub-ABCD/dwi/sub-ABCD_acq-10per000_space-T1w_desc-preproc_model-mapmri_mdp-RTOP_dwimap.nii.gz

--- a/qsirecon/tests/test_cli.py
+++ b/qsirecon/tests/test_cli.py
@@ -210,6 +210,7 @@ def test_dipy_mapmri(data_dir, output_dir, working_dir):
         f"-w={work_dir}",
         "--sloppy",
         "--recon-spec=dipy_mapmri",
+        "--output-resolution=5",
     ]
 
     _run_and_generate(TEST_NAME, parameters, test_main=True)

--- a/qsirecon/workflows/recon/dipy.py
+++ b/qsirecon/workflows/recon/dipy.py
@@ -459,7 +459,9 @@ def init_dipy_mapmri_recon_wf(
             ('perng', 'ngperp_file'),
             ('msd', 'msd_file'),
             ('qiv', 'qiv_file'),
-            ('lapnorm', 'lapnorm_file')]),
+            ('lapnorm', 'lapnorm_file'),
+            ('mapmri_coeffs', 'mapcoeffs_file'),
+        ]),
         (recon_scalars, outputnode, [("scalar_info", "recon_scalars")])
     ])  # fmt:skip
     if plot_reports:


### PR DESCRIPTION
Closes #54.

## Changes proposed in this pull request

- Write out ng, perng, and parng files if a `MAPMRI_reconstruction` node in the reconstruction workflow has `anisotropic_scaling` set to True.
- Write out the coeffs file.