### PR TITLE
Bump qsirecon_build image version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ orbs:
 
 .dockersetup: &dockersetup
   docker:
-    - image: pennlinc/qsirecon_build:24.8.1
+    - image: pennlinc/qsirecon_build:24.8.2
   working_directory: /src/qsirecon
 
 runinstall: &runinstall

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ orbs:
 
 .dockersetup: &dockersetup
   docker:
-    - image: pennlinc/qsirecon_build:24.8.2
+    - image: pennlinc/qsirecon_build:24.8.3
   working_directory: /src/qsirecon
 
 runinstall: &runinstall

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN pip install build
 RUN apt-get update && \
     apt-get install -y --no-install-recommends git
 
-FROM pennlinc/qsirecon_build:24.8.1
+FROM pennlinc/qsirecon_build:24.8.2
 
 # Install qsirecon
 COPY . /src/qsirecon

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN pip install build
 RUN apt-get update && \
     apt-get install -y --no-install-recommends git
 
-FROM pennlinc/qsirecon_build:24.8.2
+FROM pennlinc/qsirecon_build:24.8.3
 
 # Install qsirecon
 COPY . /src/qsirecon


### PR DESCRIPTION
Closes none.

## Changes proposed in this pull request

- Use the new version of qsirecon_build, which has pre-cached MNI152NLin2009cAsym and MNIInfant+2 templates.