### PR TITLE
Remove unused `--longitudinal` argument

### DIFF
--- a/qsirecon/cli/parser.py
+++ b/qsirecon/cli/parser.py
@@ -246,11 +246,6 @@ def _build_parser(**kwargs):
         "--infant", action="store_true", help="configure pipelines to process infant brains"
     )
     g_conf.add_argument(
-        "--longitudinal",
-        action="store_true",
-        help="Treat dataset as longitudinal - may increase runtime",
-    )
-    g_conf.add_argument(
         "--b0-threshold",
         "--b0_threshold",
         action="store",

--- a/qsirecon/config.py
+++ b/qsirecon/config.py
@@ -551,8 +551,6 @@ class workflow(_Config):
     """Any value in the .bval file less than this will be considered a b=0 image."""
     infant = False
     """Configure pipelines specifically for infant brains"""
-    longitudinal = False
-    """Run FreeSurfer ``recon-all`` with the ``-logitudinal`` flag."""
     input_type = None
     """Specifies which pipeline was used to preprocess data in ``bids_dir``."""
     recon_spec = None

--- a/tests/get_data.py
+++ b/tests/get_data.py
@@ -57,7 +57,6 @@ def get_default_cli_args():
         debug=True,
         low_mem=False,
         anat_only=False,
-        longitudinal=False,
         combine_all_dwis=True,
         dwi_denoise_window=0,
         denoise_before_combining=True,


### PR DESCRIPTION
Closes #47. We can add it back in in the future if necessary.

## Changes proposed in this pull request

- Remove the `--longitudinal` CLI parameter and config field. It's unused at the moment.