### PR TITLE
Fix how bundles to be tracked are selected for DSIstudio autotrack

### DIFF
--- a/qsirecon/interfaces/dsi_studio.py
+++ b/qsirecon/interfaces/dsi_studio.py
@@ -844,7 +844,7 @@ def _get_dsi_studio_bundles(desired_bundles=""):
         for bundle in bundle_candidates:
             num_underscores = bundle.count("_")
             # All bundle names with one underscore (parent bundles) will be tracked
-            # by DSIStudio by default
+            # by DSIstudio by default
             if num_underscores == 1:
                 matching_bundles.add(bundle)
             elif num_underscores == 2:

--- a/qsirecon/interfaces/dsi_studio.py
+++ b/qsirecon/interfaces/dsi_studio.py
@@ -838,20 +838,24 @@ def _get_dsi_studio_bundles(desired_bundles=""):
     def get_bundles(search_string):
         # This needs to be a set to avoid adding parent bundles several times
         matching_bundles = set()
-        bundle_candidates = [bundle for bundle in all_bundles if search_string.lower() in bundle.lower()]
+        bundle_candidates = [
+            bundle for bundle in all_bundles if search_string.lower() in bundle.lower()
+        ]
         for bundle in bundle_candidates:
-            num_underscores = bundle.count('_')
-            # All bundle names with one underscore (parent bundles) will be tracked by DSIStudio by default
+            num_underscores = bundle.count("_")
+            # All bundle names with one underscore (parent bundles) will be tracked
+            # by DSIStudio by default
             if num_underscores == 1:
                 matching_bundles.add(bundle)
             elif num_underscores == 2:
                 # All sub bundles will only be tracked if they have been specifically specified
                 if bundle == search_string:
                     matching_bundles.add(bundle)
-                # If sub bundles have not been specifically specified, their parent bundle will be tracked 
+                # If sub bundles have not been specifically specified, their parent bundle
+                # will be tracked
                 else:
-                    parent_bundle = '_'.join(bundle.split('_')[:2])
-                    matching_bundles.add(parent_bundle)      
+                    parent_bundle = "_".join(bundle.split("_")[:2])
+                    matching_bundles.add(parent_bundle)
         return list(matching_bundles)
 
     # Figure out which bundles we'll be tracking

--- a/qsirecon/interfaces/dsi_studio.py
+++ b/qsirecon/interfaces/dsi_studio.py
@@ -836,7 +836,23 @@ def _get_dsi_studio_bundles(desired_bundles=""):
         return all_bundles
 
     def get_bundles(search_string):
-        return [bundle for bundle in all_bundles if search_string.lower() in bundle.lower()]
+        # This needs to be a set to avoid adding parent bundles several times
+        matching_bundles = set()
+        bundle_candidates = [bundle for bundle in all_bundles if search_string.lower() in bundle.lower()]
+        for bundle in bundle_candidates:
+            num_underscores = bundle.count('_')
+            # All bundle names with one underscore (parent bundles) will be tracked by DSIStudio by default
+            if num_underscores == 1:
+                matching_bundles.add(bundle)
+            elif num_underscores == 2:
+                # All sub bundles will only be tracked if they have been specifically specified
+                if bundle == search_string:
+                    matching_bundles.add(bundle)
+                # If sub bundles have not been specifically specified, their parent bundle will be tracked 
+                else:
+                    parent_bundle = '_'.join(bundle.split('_')[:2])
+                    matching_bundles.add(parent_bundle)      
+        return list(matching_bundles)
 
     # Figure out which bundles we'll be tracking
     bundles_to_track = []


### PR DESCRIPTION


<!--
Text in these brackets are comments, and won't be visible when you submit your pull request.
If this is your first contribution, please take the time to read these, in particular the comment
beginning "Welcome, new contributors!".
-->

## Changes proposed in this pull request

The get_bundle function was updated to select parent bundles  by default and only select sub bundles if their name was explicitly stated in the `track_id` parameter in the recon spec.

This PR addresses the following issue: #120 


## Documentation that should be reviewed
<!--
Please summarize here the main changes to the documentation that the reviewers should be aware of.
-->
-


<!--
Welcome, new contributors!

We ask you to read through the Contributing Guide:
https://github.com/pennlinc/qsirecon/blob/main/CONTRIBUTING.md

These are guidelines intended to make communication easier by describing a consistent process, but
don't worry if you don't get it everything exactly "right" on the first try.

To boil it down, here are some highlights:

1) Consider starting a conversation in the issues list before submitting a pull request. The discussion might save you a
   lot of time coding.
2) Please use descriptive prefixes in your pull request title, such as "ENH:" for an enhancement or "FIX:" for a bug fix.
   (See the Contributing guide for the full set.) And consider adding a "WIP" tag for works-in-progress.
3) Any code you submit will be licensed under the same terms (BSD 3-Clause) as the rest of QSIRecon.

A pull request is a conversation. We may ask you to make some changes before accepting your PR,
and likewise, you should feel free to ask us any questions you have.

-->
