### PR TITLE
Rename `--freesurfer-input` to `--fs-subjects-dir`

### DIFF
--- a/.circleci/FreeSurferIngressTest.sh
+++ b/.circleci/FreeSurferIngressTest.sh
@@ -24,7 +24,7 @@ ${QSIRECON_CMD} \
 	 --recon-input ${BIDS_INPUT_DIR} \
 	 --sloppy \
 	 --recon-spec ${PWD}/test_5tt_hsv.json \
-	 --freesurfer-input ${SUBJECTS_DIR} \
+	 --fs-subjects-dir ${SUBJECTS_DIR} \
 	 --recon-only \
 	 -vv --debug pdb
 

--- a/docs/builtin_workflows.rst
+++ b/docs/builtin_workflows.rst
@@ -47,7 +47,7 @@ structural connectivity matrix.
   We don't recommend using ACT with FAST segmentations. The full benefits of ACT
   require very precise tissue boundaries and FAST just doesn't do this reliably
   enough. We strongly recommend the ``hsvs`` segmentation if you're going to
-  use ACT. Note that this requires ``--freesurfer-input``
+  use ACT. Note that this requires ``--fs-subjects-dir``
 
 .. _mrtrix_dwi_outputs:
 
@@ -81,7 +81,7 @@ This workflow uses the ``msmt_csd`` algorithm :footcite:p:`msmt5tt` to estimate 
 gray matter and cerebrospinal fluid using *multi-shell acquisitions*. The white matter FODs are
 used for tractography and the T1w segmentation is used for anatomical constraints :footcite:p:`smith2012anatomically`.
 The T1w segmentation uses the hybrid surface volume segmentation (hsvs) :footcite:p:`smith2020hybrid` and
-requires ``--freesurfer-input``.
+requires ``--fs-subjects-dir``.
 This workflow produces :ref:`mrtrix_dwi_outputs` and :ref:`mrtrix_anatomical_outputs`.
 
 .. _mrtrix_multishell_msmt_ACT-fast:
@@ -117,7 +117,7 @@ to estimate FODs for white matter,
 and cerebrospinal fluid using *single shell (DTI) acquisitions*. The white matter FODs are
 used for tractography and the T1w segmentation is used for anatomical constraints :footcite:p:`smith2012anatomically`.
 The T1w segmentation uses the hybrid surface volume segmentation (hsvs) :footcite:p:`smith2020hybrid` and
-requires ``--freesurfer-input``.
+requires ``--fs-subjects-dir``.
 This workflow produces :ref:`mrtrix_dwi_outputs` and :ref:`mrtrix_anatomical_outputs`.
 
 .. _mrtrix_singleshell_ss3t_ACT-fast:

--- a/docs/input_data.rst
+++ b/docs/input_data.rst
@@ -115,7 +115,7 @@ Including FreeSurfer Data
 =========================
 
 Suppose you ran FreeSurfer on your data (e.g. as part of fmriprep). You can
-specify the directory containing freesurfer outputs with the ``--freesurfer-input`` flag. If you
+specify the directory containing freesurfer outputs with the ``--fs-subjects-dir`` flag. If you
 have::
 
     derivatives/freesurfer/sub-x
@@ -145,7 +145,7 @@ You can run:
        --omp-nthreads 8 \
        --fs-license-file /license.txt \
        --recon-spec mrtrix_multishell_msmt_ACT-hsvs \
-       --freesurfer-input "${PWD}/derivatives/freesurfer" \
+       --fs-subjects-dir "${PWD}/derivatives/freesurfer" \
        -v -v
 
 This will read the FreeSurfer data, align it to the ``qsiprep`` results and use it

--- a/qsirecon/cli/parser.py
+++ b/qsirecon/cli/parser.py
@@ -347,8 +347,8 @@ def _build_parser(**kwargs):
         ),
     )
     g_recon.add_argument(
-        "--freesurfer-input",
-        "--freesurfer_input",
+        "--fs-subjects-dir",
+        "--fs_subjects_dir",
         action="store",
         metavar="PATH",
         type=Path,

--- a/qsirecon/cli/parser.py
+++ b/qsirecon/cli/parser.py
@@ -351,8 +351,11 @@ def _build_parser(**kwargs):
         "--fs_subjects_dir",
         action="store",
         metavar="PATH",
-        type=Path,
-        help="Directory containing freesurfer outputs to be integrated into recon.",
+        type=PathExists,
+        help=(
+            "Directory containing Freesurfer outputs to be integrated into recon. "
+            "Freesurfer must already be run. QSIRecon will not run Freesurfer."
+        ),
     )
     g_recon.add_argument(
         "--skip-odf-reports",

--- a/qsirecon/config.py
+++ b/qsirecon/config.py
@@ -428,8 +428,6 @@ class execution(_Config):
     """Disable ODF recon reports."""
     participant_label = None
     """List of participant identifiers that are to be preprocessed."""
-    freesurfer_input = None
-    """Directory containing FreeSurfer directories to use for recon workflows."""
     templateflow_home = _templateflow_home
     """The root folder of the TemplateFlow client."""
     work_dir = Path("work").absolute()
@@ -453,7 +451,6 @@ class execution(_Config):
         "eddy_config",
         "fs_license_file",
         "fs_subjects_dir",
-        "freesurfer_input",
         "layout",
         "log_dir",
         "output_dir",

--- a/qsirecon/tests/test_cli.py
+++ b/qsirecon/tests/test_cli.py
@@ -88,7 +88,7 @@ def test_mrtrix_multishell_msmt_hsvs(data_dir, output_dir, working_dir):
         "participant",
         f"-w={work_dir}",
         "--sloppy",
-        f"--freesurfer-input={freesurfer_dir}",
+        f"--fs-subjects-dir={freesurfer_dir}",
         "--recon-spec=mrtrix_multishell_msmt_ACT-hsvs",
         "--atlases",
         "AAL116",

--- a/qsirecon/workflows/recon/anatomical.py
+++ b/qsirecon/workflows/recon/anatomical.py
@@ -70,7 +70,7 @@ def init_highres_recon_anatomical_wf(
 
     # If there is no high-res anat data in the inputs there may still be an image available
     # from freesurfer. Check for it:
-    freesurfer_dir = config.execution.freesurfer_input
+    freesurfer_dir = config.execution.fs_subjects_dir
     subject_freesurfer_path = find_fs_path(freesurfer_dir, subject_id)
     status["has_freesurfer"] = subject_freesurfer_path is not None
     status["has_qsiprep_5tt_hsvs"] = False


### PR DESCRIPTION
Closes #45 and closes #139.

## Changes proposed in this pull request

- Rename the `--freesurfer-input` parameter to `--fs-subjects-dir`.
    - I noticed that QSIRecon was using `fs_subjects_dir` in places where it was probably supposed to be using `freesurfer_input`, so this almost certainly fixes some bugs.
- Explicitly check that the `fs_subjects_dir` exists in the parser. This should fix #139.