### PR TITLE
Pass DWI file metadata to reconstruction workflows

### DIFF
--- a/qsirecon/workflows/base.py
+++ b/qsirecon/workflows/base.py
@@ -241,6 +241,12 @@ to workflows in *QSIRecon*'s documentation]\
             **status,
         )
 
+        inputs_dict = {
+            "dwi_file": dwi_file,
+            "dwi_metadata": config.execution.layout.get_metadata(dwi_file),
+            **dwi_available_anatomical_data,
+        }
+
         # This node holds all the inputs that will go to the recon workflow.
         # It is the definitive place to check what the input files are
         recon_full_inputs[dwi_file] = pe.Node(
@@ -250,7 +256,7 @@ to workflows in *QSIRecon*'s documentation]\
 
         # This is the actual recon workflow for this dwi file
         dwi_recon_wfs[dwi_file] = init_dwi_recon_workflow(
-            available_anatomical_data=dwi_available_anatomical_data,
+            inputs_dict=inputs_dict,
             workflow_spec=spec,
             name=f"{wf_name}_recon_wf",
         )

--- a/qsirecon/workflows/recon/amico.py
+++ b/qsirecon/workflows/recon/amico.py
@@ -24,7 +24,7 @@ from qsirecon.data import load as load_data
 
 
 def init_amico_noddi_fit_wf(
-    available_anatomical_data,
+    inputs_dict,
     name="amico_noddi_recon",
     qsirecon_suffix="",
     params={},

--- a/qsirecon/workflows/recon/anatomical.py
+++ b/qsirecon/workflows/recon/anatomical.py
@@ -326,12 +326,26 @@ def init_dwi_recon_anatomical_workflow(
         brain parcellations.
       * ``"odf_rois"``: An image with some interesting ROIs for plotting ODFs
 
-    Parameters:
-    ===========
-        has_qsiprep_5tt_hsvs:
-        has_freesurfer_5tt_hsvs: True,
-        has_qsiprep_t1w:
-        has_qsiprep_t1w_transforms: True}
+    Parameters
+    ----------
+    has_qsiprep_5tt_hsvs : bool
+    has_freesurfer_5tt_hsvs : bool
+    has_qsiprep_t1w : bool
+    has_qsiprep_t1w_transforms : bool
+
+    Returns
+    -------
+    workflow : nipype Workflow
+        The workflow that calculates the necessary anatomical data
+    status : dict
+        A dictionary with the status of the anatomical data, with the following keys:
+
+        - ``has_qsiprep_5tt_hsvs``
+        - ``has_freesurfer_5tt_hsvs``
+        - ``has_qsiprep_t1w``
+        - ``has_qsiprep_t1w_transforms``
+
+        Each value is a boolean indicating whether the data is available.
     """
     # Inputnode holds data from the T1w-based anatomical workflow
     inputnode = pe.Node(

--- a/qsirecon/workflows/recon/build_workflow.py
+++ b/qsirecon/workflows/recon/build_workflow.py
@@ -39,10 +39,22 @@ def _check_repeats(nodelist):
 
 def init_dwi_recon_workflow(
     workflow_spec,
-    available_anatomical_data,
+    inputs_dict,
     name="recon_wf",
 ):
-    """Convert a workflow spec into a nipype workflow."""
+    """Convert a workflow spec into a nipype workflow.
+
+    Parameters
+    ----------
+    workflow_spec : dict
+        A dictionary that describes the workflow to be built.
+    inputs_dict : dict
+        A dictionary of inputs to the workflow.
+        Keys include "dwi_file" (path to the DWI file),
+        "dwi_metadata" (metadata for the DWI file),
+        and the keys from the ``status`` output of
+        :func:`~qsirecon.workflows.recon.anatomical.init_dwi_recon_anatomical_workflow`.
+    """
 
     workflow = Workflow(name=name)
     inputnode = pe.Node(
@@ -56,7 +68,7 @@ def init_dwi_recon_workflow(
             raise Exception(f"Node has no name [{node_spec}]")
 
         new_node = workflow_from_spec(
-            available_anatomical_data=available_anatomical_data,
+            inputs_dict=inputs_dict,
             node_spec=node_spec,
         )
         if new_node is None:
@@ -178,7 +190,7 @@ def init_dwi_recon_workflow(
     return workflow
 
 
-def workflow_from_spec(available_anatomical_data, node_spec):
+def workflow_from_spec(inputs_dict, node_spec):
     """Build a nipype workflow based on a json file."""
     software = node_spec.get("software", "qsirecon")
     qsirecon_suffix = node_spec.get("qsirecon_suffix", "")
@@ -200,7 +212,7 @@ def workflow_from_spec(available_anatomical_data, node_spec):
     if node_name is None:
         raise Exception('Node %s must have a "name" attribute' % node_spec)
     kwargs = {
-        "available_anatomical_data": available_anatomical_data,
+        "inputs_dict": inputs_dict,
         "name": node_name,
         "qsirecon_suffix": qsirecon_suffix,
         "params": parameters,

--- a/qsirecon/workflows/recon/converters.py
+++ b/qsirecon/workflows/recon/converters.py
@@ -23,7 +23,7 @@ LOGGER = logging.getLogger("nipype.workflow")
 
 
 def init_mif_to_fibgz_wf(
-    available_anatomical_data, name="mif_to_fibgz", qsirecon_suffix="", params={}
+    inputs_dict, name="mif_to_fibgz", qsirecon_suffix="", params={}
 ):
     """Converts a MRTrix mif file to DSI Studio fib file.
 
@@ -96,7 +96,7 @@ def init_fibgz_to_mif_wf(name="fibgz_to_mif", qsirecon_suffix="", params={}):
 
 
 def init_qsirecon_to_fsl_wf(
-    available_anatomical_data, name="qsirecon_to_fsl", qsirecon_suffix="", params={}
+    inputs_dict, name="qsirecon_to_fsl", qsirecon_suffix="", params={}
 ):
     """Converts QSIRecon outputs (images, bval, bvec) to fsl standard orientation"""
     inputnode = pe.Node(

--- a/qsirecon/workflows/recon/converters.py
+++ b/qsirecon/workflows/recon/converters.py
@@ -22,9 +22,7 @@ from ...utils.bids import clean_datasinks
 LOGGER = logging.getLogger("nipype.workflow")
 
 
-def init_mif_to_fibgz_wf(
-    inputs_dict, name="mif_to_fibgz", qsirecon_suffix="", params={}
-):
+def init_mif_to_fibgz_wf(inputs_dict, name="mif_to_fibgz", qsirecon_suffix="", params={}):
     """Converts a MRTrix mif file to DSI Studio fib file.
 
     This workflow uses ``sh2amp`` to sample the FODs on the standard DSI Studio
@@ -95,9 +93,7 @@ def init_fibgz_to_mif_wf(name="fibgz_to_mif", qsirecon_suffix="", params={}):
     return clean_datasinks(workflow, qsirecon_suffix)
 
 
-def init_qsirecon_to_fsl_wf(
-    inputs_dict, name="qsirecon_to_fsl", qsirecon_suffix="", params={}
-):
+def init_qsirecon_to_fsl_wf(inputs_dict, name="qsirecon_to_fsl", qsirecon_suffix="", params={}):
     """Converts QSIRecon outputs (images, bval, bvec) to fsl standard orientation"""
     inputnode = pe.Node(
         niu.IdentityInterface(fields=recon_workflow_input_fields), name="inputnode"

--- a/qsirecon/workflows/recon/dipy.py
+++ b/qsirecon/workflows/recon/dipy.py
@@ -67,7 +67,7 @@ def external_format_datasinks(qsirecon_suffix, params, wf):
 
 
 def init_dipy_brainsuite_shore_recon_wf(
-    available_anatomical_data,
+    inputs_dict,
     name="dipy_3dshore_recon",
     qsirecon_suffix="",
     params={},
@@ -213,7 +213,7 @@ def init_dipy_brainsuite_shore_recon_wf(
         ])  # fmt:skip
 
     # Plot targeted regions
-    if available_anatomical_data["has_qsiprep_t1w_transforms"] and plot_reports:
+    if inputs_dict["has_qsiprep_t1w_transforms"] and plot_reports:
         ds_report_odfs = pe.Node(
             DerivativesDataSink(
                 desc="3dSHOREODF",
@@ -347,7 +347,7 @@ def init_dipy_brainsuite_shore_recon_wf(
 
 
 def init_dipy_mapmri_recon_wf(
-    available_anatomical_data,
+    inputs_dict,
     name="dipy_mapmri_recon",
     qsirecon_suffix="",
     params={},
@@ -517,7 +517,7 @@ def init_dipy_mapmri_recon_wf(
         ])  # fmt:skip
 
     # Plot targeted regions
-    if available_anatomical_data["has_qsiprep_t1w_transforms"] and plot_reports:
+    if inputs_dict["has_qsiprep_t1w_transforms"] and plot_reports:
         ds_report_odfs = pe.Node(
             DerivativesDataSink(
                 desc="MAPLMRIODF",
@@ -544,7 +544,7 @@ def init_dipy_mapmri_recon_wf(
 
 
 def init_dipy_dki_recon_wf(
-    available_anatomical_data, name="dipy_dki_recon", qsirecon_suffix="", params={}
+    inputs_dict, name="dipy_dki_recon", qsirecon_suffix="", params={}
 ):
     """Fit DKI
 

--- a/qsirecon/workflows/recon/dipy.py
+++ b/qsirecon/workflows/recon/dipy.py
@@ -543,9 +543,7 @@ def init_dipy_mapmri_recon_wf(
     return clean_datasinks(workflow, qsirecon_suffix)
 
 
-def init_dipy_dki_recon_wf(
-    inputs_dict, name="dipy_dki_recon", qsirecon_suffix="", params={}
-):
+def init_dipy_dki_recon_wf(inputs_dict, name="dipy_dki_recon", qsirecon_suffix="", params={}):
     """Fit DKI
 
     Inputs

--- a/qsirecon/workflows/recon/dsi_studio.py
+++ b/qsirecon/workflows/recon/dsi_studio.py
@@ -44,7 +44,7 @@ LOGGER = logging.getLogger("nipype.interface")
 
 
 def init_dsi_studio_recon_wf(
-    available_anatomical_data, name="dsi_studio_recon", qsirecon_suffix="", params={}
+    inputs_dict, name="dsi_studio_recon", qsirecon_suffix="", params={}
 ):
     """Reconstructs diffusion data using DSI Studio.
 
@@ -128,7 +128,7 @@ distance of %02f in DSI Studio (version %s). """ % (
         ])  # fmt:skip
 
         # Plot targeted regions
-        if available_anatomical_data["has_qsiprep_t1w_transforms"]:
+        if inputs_dict["has_qsiprep_t1w_transforms"]:
             ds_report_odfs = pe.Node(
                 DerivativesDataSink(
                     desc="GQIODF",
@@ -160,7 +160,7 @@ distance of %02f in DSI Studio (version %s). """ % (
 
 
 def init_dsi_studio_tractography_wf(
-    available_anatomical_data,
+    inputs_dict,
     name="dsi_studio_tractography",
     params={},
     qsirecon_suffix="",
@@ -265,7 +265,7 @@ def init_dsi_studio_tractography_wf(
 
 
 def init_dsi_studio_autotrack_wf(
-    available_anatomical_data,
+    inputs_dict,
     params={},
     qsirecon_suffix="",
     name="dsi_studio_autotrack_wf",
@@ -418,7 +418,7 @@ def init_dsi_studio_autotrack_wf(
 
 
 def init_dsi_studio_connectivity_wf(
-    available_anatomical_data,
+    inputs_dict,
     name="dsi_studio_connectivity",
     params={},
     qsirecon_suffix="",
@@ -544,7 +544,7 @@ def init_dsi_studio_connectivity_wf(
 
 
 def init_dsi_studio_export_wf(
-    available_anatomical_data,
+    inputs_dict,
     name="dsi_studio_export",
     params={},
     qsirecon_suffix="",

--- a/qsirecon/workflows/recon/dsi_studio.py
+++ b/qsirecon/workflows/recon/dsi_studio.py
@@ -43,9 +43,7 @@ from .utils import init_scalar_output_wf
 LOGGER = logging.getLogger("nipype.interface")
 
 
-def init_dsi_studio_recon_wf(
-    inputs_dict, name="dsi_studio_recon", qsirecon_suffix="", params={}
-):
+def init_dsi_studio_recon_wf(inputs_dict, name="dsi_studio_recon", qsirecon_suffix="", params={}):
     """Reconstructs diffusion data using DSI Studio.
 
     This workflow creates a ``.src.gz`` file from the input dwi, bvals and bvecs,

--- a/qsirecon/workflows/recon/mrtrix.py
+++ b/qsirecon/workflows/recon/mrtrix.py
@@ -51,7 +51,7 @@ CITATIONS = {
 
 
 def init_mrtrix_csd_recon_wf(
-    available_anatomical_data, name="mrtrix_recon", qsirecon_suffix="", params={}
+    inputs_dict, name="mrtrix_recon", qsirecon_suffix="", params={}
 ):
     """Create FOD images for WM, GM and CSF.
 
@@ -261,7 +261,7 @@ def init_mrtrix_csd_recon_wf(
         ])  # fmt:skip
 
         # Plot targeted regions
-        if available_anatomical_data["has_qsiprep_t1w_transforms"]:
+        if inputs_dict["has_qsiprep_t1w_transforms"]:
             ds_report_odfs = pe.Node(
                 DerivativesDataSink(
                     desc="wmFOD",
@@ -406,7 +406,7 @@ def init_mrtrix_csd_recon_wf(
 
 
 def init_global_tractography_wf(
-    available_anatomical_data, name="mrtrix_recon", qsirecon_suffix="", params={}
+    inputs_dict, name="mrtrix_recon", qsirecon_suffix="", params={}
 ):
     """Run multi-shell, multi-tissue global tractography
 
@@ -526,7 +526,7 @@ def init_global_tractography_wf(
 
 
 def init_mrtrix_tractography_wf(
-    available_anatomical_data, name="mrtrix_tracking", qsirecon_suffix="", params={}
+    inputs_dict, name="mrtrix_tracking", qsirecon_suffix="", params={}
 ):
     """Run tractography
 
@@ -647,7 +647,7 @@ def init_mrtrix_tractography_wf(
 
 
 def init_mrtrix_connectivity_wf(
-    available_anatomical_data,
+    inputs_dict,
     name="mrtrix_connectiity",
     params={},
     qsirecon_suffix="",

--- a/qsirecon/workflows/recon/mrtrix.py
+++ b/qsirecon/workflows/recon/mrtrix.py
@@ -50,9 +50,7 @@ CITATIONS = {
 }
 
 
-def init_mrtrix_csd_recon_wf(
-    inputs_dict, name="mrtrix_recon", qsirecon_suffix="", params={}
-):
+def init_mrtrix_csd_recon_wf(inputs_dict, name="mrtrix_recon", qsirecon_suffix="", params={}):
     """Create FOD images for WM, GM and CSF.
 
     This workflow uses mrtrix tools to run csd on multishell data. At the end,
@@ -405,9 +403,7 @@ def init_mrtrix_csd_recon_wf(
     return clean_datasinks(workflow, qsirecon_suffix)
 
 
-def init_global_tractography_wf(
-    inputs_dict, name="mrtrix_recon", qsirecon_suffix="", params={}
-):
+def init_global_tractography_wf(inputs_dict, name="mrtrix_recon", qsirecon_suffix="", params={}):
     """Run multi-shell, multi-tissue global tractography
 
     This workflow uses mrtrix tools to run csd on multishell data.

--- a/qsirecon/workflows/recon/pyafq.py
+++ b/qsirecon/workflows/recon/pyafq.py
@@ -49,7 +49,7 @@ def _parse_qsirecon_params_dict(params_dict):
     return kwargs
 
 
-def init_pyafq_wf(available_anatomical_data, name="afq", qsirecon_suffix="", params={}):
+def init_pyafq_wf(inputs_dict, name="afq", qsirecon_suffix="", params={}):
     """Run PyAFQ on some qsirecon outputs
 
     Inputs

--- a/qsirecon/workflows/recon/scalar_mapping.py
+++ b/qsirecon/workflows/recon/scalar_mapping.py
@@ -27,7 +27,7 @@ LOGGER = logging.getLogger("nipype.workflow")
 
 
 def init_scalar_to_bundle_wf(
-    available_anatomical_data, name="scalar_to_bundle", qsirecon_suffix="", params={}
+    inputs_dict, name="scalar_to_bundle", qsirecon_suffix="", params={}
 ):
     """Map scalar images to bundles
 
@@ -86,7 +86,7 @@ def init_scalar_to_bundle_wf(
 
 
 def init_scalar_to_atlas_wf(
-    available_anatomical_data,
+    inputs_dict,
     name="scalar_to_template",
     qsirecon_suffix="",
     params={},
@@ -138,7 +138,7 @@ def init_scalar_to_atlas_wf(
 
 
 def init_scalar_to_template_wf(
-    available_anatomical_data,
+    inputs_dict,
     name="scalar_to_template",
     qsirecon_suffix="",
     params={},
@@ -191,7 +191,7 @@ def init_scalar_to_template_wf(
 
 
 def init_scalar_to_surface_wf(
-    available_anatomical_data,
+    inputs_dict,
     name="scalar_to_surface",
     qsirecon_suffix="",
     params={},

--- a/qsirecon/workflows/recon/scalar_mapping.py
+++ b/qsirecon/workflows/recon/scalar_mapping.py
@@ -26,9 +26,7 @@ from .utils import init_scalar_output_wf
 LOGGER = logging.getLogger("nipype.workflow")
 
 
-def init_scalar_to_bundle_wf(
-    inputs_dict, name="scalar_to_bundle", qsirecon_suffix="", params={}
-):
+def init_scalar_to_bundle_wf(inputs_dict, name="scalar_to_bundle", qsirecon_suffix="", params={}):
     """Map scalar images to bundles
 
     Inputs

--- a/qsirecon/workflows/recon/steinhardt.py
+++ b/qsirecon/workflows/recon/steinhardt.py
@@ -14,7 +14,7 @@ LOGGER = logging.getLogger("nipype.interface")
 
 
 def init_steinhardt_order_param_wf(
-    available_anatomical_data, name="sop_recon", qsirecon_suffix="", params={}
+    inputs_dict, name="sop_recon", qsirecon_suffix="", params={}
 ):
     """Compute Steinhardt order parameters based on ODFs or FODs
 

--- a/qsirecon/workflows/recon/steinhardt.py
+++ b/qsirecon/workflows/recon/steinhardt.py
@@ -13,9 +13,7 @@ from ...utils.bids import clean_datasinks
 LOGGER = logging.getLogger("nipype.interface")
 
 
-def init_steinhardt_order_param_wf(
-    inputs_dict, name="sop_recon", qsirecon_suffix="", params={}
-):
+def init_steinhardt_order_param_wf(inputs_dict, name="sop_recon", qsirecon_suffix="", params={}):
     """Compute Steinhardt order parameters based on ODFs or FODs
 
     Inputs

--- a/qsirecon/workflows/recon/tortoise.py
+++ b/qsirecon/workflows/recon/tortoise.py
@@ -113,6 +113,13 @@ def init_tortoise_estimator_wf(inputs_dict, name="tortoise_recon", qsirecon_suff
     # Do we have deltas?
     deltas = (params.get("big_delta", None), params.get("small_delta", None))
     approximate_deltas = None in deltas
+    dwi_metadata = inputs_dict.get("dwi_metadata", {})
+    if approximate_deltas:
+        deltas = (
+            dwi_metadata.get("LargeDelta", None),
+            dwi_metadata.get("SmallDelta", None),
+        )
+        approximate_deltas = None in deltas
 
     # TORTOISE requires unzipped float32 nifti files and a bmtxt file.
     tortoise_convert = pe.Node(TORTOISEConvert(), name="tortoise_convert")

--- a/qsirecon/workflows/recon/tortoise.py
+++ b/qsirecon/workflows/recon/tortoise.py
@@ -42,7 +42,7 @@ CITATIONS = {
 
 
 def init_tortoise_estimator_wf(
-    available_anatomical_data, name="tortoise_recon", qsirecon_suffix="", params={}
+    inputs_dict, name="tortoise_recon", qsirecon_suffix="", params={}
 ):
     """Run estimators from TORTOISE.
 

--- a/qsirecon/workflows/recon/tortoise.py
+++ b/qsirecon/workflows/recon/tortoise.py
@@ -41,9 +41,7 @@ CITATIONS = {
 }
 
 
-def init_tortoise_estimator_wf(
-    inputs_dict, name="tortoise_recon", qsirecon_suffix="", params={}
-):
+def init_tortoise_estimator_wf(inputs_dict, name="tortoise_recon", qsirecon_suffix="", params={}):
     """Run estimators from TORTOISE.
 
     This workflow may run ``EstimateTensor`` and/or ``EstimateMAPMRI``

--- a/qsirecon/workflows/recon/utils.py
+++ b/qsirecon/workflows/recon/utils.py
@@ -23,9 +23,7 @@ from qsirecon.interfaces.recon_scalars import OrganizeScalarData
 LOGGER = logging.getLogger("nipype.workflow")
 
 
-def init_conform_dwi_wf(
-    inputs_dict, name="conform_dwi", qsirecon_suffix="", params={}
-):
+def init_conform_dwi_wf(inputs_dict, name="conform_dwi", qsirecon_suffix="", params={}):
     """If data were preprocessed elsewhere, ensure the gradients and images
     conform to LPS+ before running other parts of the pipeline."""
     inputnode = pe.Node(

--- a/qsirecon/workflows/recon/utils.py
+++ b/qsirecon/workflows/recon/utils.py
@@ -24,7 +24,7 @@ LOGGER = logging.getLogger("nipype.workflow")
 
 
 def init_conform_dwi_wf(
-    available_anatomical_data, name="conform_dwi", qsirecon_suffix="", params={}
+    inputs_dict, name="conform_dwi", qsirecon_suffix="", params={}
 ):
     """If data were preprocessed elsewhere, ensure the gradients and images
     conform to LPS+ before running other parts of the pipeline."""
@@ -55,7 +55,7 @@ def init_conform_dwi_wf(
 
 
 def init_discard_repeated_samples_wf(
-    available_anatomical_data,
+    inputs_dict,
     name="discard_repeats",
     qsirecon_suffix="",
     space="T1w",


### PR DESCRIPTION
Closes none.

Changes proposed:

- Rename `available_anatomical_data` to `inputs_dict`.
- Add `dwi_file` and `dwi_metadata` fields to `inputs_dict` for the recon workflows to use. In particular, `dwi_metadata` will be used to get `LargeDelta` and `SmallDelta`.
- Use LargeDelta and SmallDelta to set `init_tortoise_estimator_wf` recon workflow parameters.