### PR TITLE
[FIX] set TMPDIR before running plot_peaks

### DIFF
--- a/qsirecon/cli/recon_plot.py
+++ b/qsirecon/cli/recon_plot.py
@@ -101,6 +101,7 @@ def recon_plot():
     parser.add_argument("--padding", type=int, default=10, help="number of slices to plot")
     opts = parser.parse_args()
 
+    print(f"TMPDIR={os.getenv('TMPDIR')}")
     if opts.mif:
         odf_img, directions = mif2amps(opts.mif, os.getcwd())
         LOGGER.info("converting %s to plot ODF/peaks", opts.mif)

--- a/qsirecon/workflows/recon/amico.py
+++ b/qsirecon/workflows/recon/amico.py
@@ -125,7 +125,11 @@ diffusivity.""" % (
     ])  # fmt:skip
 
     if plot_reports:
-        plot_peaks = pe.Node(CLIReconPeaksReport(), name="plot_peaks", n_procs=omp_nthreads)
+        plot_peaks = pe.Node(
+            CLIReconPeaksReport(environ={"TMPDIR": str(config.execution.work_dir)}),
+            name="plot_peaks",
+            n_procs=omp_nthreads,
+        )
         ds_report_peaks = pe.Node(
             DerivativesDataSink(
                 datatype="figures",

--- a/qsirecon/workflows/recon/dipy.py
+++ b/qsirecon/workflows/recon/dipy.py
@@ -189,7 +189,11 @@ def init_dipy_brainsuite_shore_recon_wf(
     ])  # fmt:skip
 
     if plot_reports:
-        plot_peaks = pe.Node(CLIReconPeaksReport(), name="plot_peaks", n_procs=omp_nthreads)
+        plot_peaks = pe.Node(
+            CLIReconPeaksReport(environ={"TMPDIR": str(config.execution.work_dir)}),
+            name="plot_peaks",
+            n_procs=omp_nthreads,
+        )
         ds_report_peaks = pe.Node(
             DerivativesDataSink(
                 desc="3dSHOREODF",
@@ -495,7 +499,11 @@ def init_dipy_mapmri_recon_wf(
     ])  # fmt:skip
 
     if plot_reports:
-        plot_peaks = pe.Node(CLIReconPeaksReport(), name="plot_peaks", n_procs=omp_nthreads)
+        plot_peaks = pe.Node(
+            CLIReconPeaksReport(environ={"TMPDIR": str(config.execution.work_dir)}),
+            name="plot_peaks",
+            n_procs=omp_nthreads,
+        )
         ds_report_peaks = pe.Node(
             DerivativesDataSink(
                 desc="MAPLMRIODF",

--- a/qsirecon/workflows/recon/dsi_studio.py
+++ b/qsirecon/workflows/recon/dsi_studio.py
@@ -104,7 +104,11 @@ distance of %02f in DSI Studio (version %s). """ % (
     if plot_reports:
         # Make a visual report of the model
         plot_peaks = pe.Node(
-            CLIReconPeaksReport(subtract_iso=True), name="plot_peaks", n_procs=omp_nthreads
+            CLIReconPeaksReport(
+                environ={"TMPDIR": str(config.execution.work_dir)}, subtract_iso=True
+            ),
+            name="plot_peaks",
+            n_procs=omp_nthreads,
         )
         ds_report_peaks = pe.Node(
             DerivativesDataSink(

--- a/qsirecon/workflows/recon/mrtrix.py
+++ b/qsirecon/workflows/recon/mrtrix.py
@@ -239,7 +239,11 @@ def init_mrtrix_csd_recon_wf(inputs_dict, name="mrtrix_recon", qsirecon_suffix="
 
     if not config.execution.skip_odf_reports:
         # Make a visual report of the model
-        plot_peaks = pe.Node(CLIReconPeaksReport(), name="plot_peaks", n_procs=omp_nthreads)
+        plot_peaks = pe.Node(
+            CLIReconPeaksReport(environ={"TMPDIR": str(config.execution.work_dir)}),
+            name="plot_peaks",
+            n_procs=omp_nthreads,
+        )
         ds_report_peaks = pe.Node(
             DerivativesDataSink(
                 desc="wmFOD",


### PR DESCRIPTION
The ODF plotting often requires the `--writable-tmpfs` flag for apptainer/singularity. This could be due to xvfb trying to use an unwritable temp dir. 