### PR TITLE
Fix extension in hsvs derivative

### DIFF
--- a/qsirecon/workflows/recon/anatomical.py
+++ b/qsirecon/workflows/recon/anatomical.py
@@ -148,6 +148,7 @@ def init_highres_recon_anatomical_wf(
                 seg="hsvs",
                 space="fsnative",
                 suffix="probseg",
+                extension=".mif.gz",
                 compress=True,
             ),
             name="ds_fs_5tt_hsvs",


### PR DESCRIPTION
Closes #162.

## Changes proposed in this pull request

- Specify extension in `ds_fs_5tt_hsvs` because it was defaulting to an invalid extension (`.long_5tt.mif.gz`).