### PR TITLE
Make connectivity field names compatible with MATLAB

### DIFF
--- a/docs/connectivity_matrices.rst
+++ b/docs/connectivity_matrices.rst
@@ -14,7 +14,7 @@ these pipelines and only look at those numbers.
 If you look at more than one weighting method be sure to adjust your statistics for the
 additional comparisons.
 
-To skip this step in your workflow, you can modify an existing recon pipeline by removing the 
+To skip this step in your workflow, you can modify an existing recon pipeline by removing the
 ``action: connectivity`` section from the yaml file.
 
 .. _connectivity_atlases:
@@ -95,6 +95,37 @@ The nifti images should be registered to the
 included in ``qsirecon``.
 It is essential that your images are in the LPS+ orientation and have the sform zeroed-out in the header.
 **Be sure to check for alignment and orientation** in your outputs.
+
+
+*********************
+Connectivity Measures
+*********************
+
+Connectivity measures are bundled together in binary ``.mat`` files,
+rather than as atlas- and measure-specific tabular files.
+
+.. code-block::
+
+   qsirecon/
+      derivatives/
+         qsirecon-<suffix>/
+            sub-<label>/[ses-<label>/]
+               dwi/
+                  <source_entities>_connectivity.mat
+
+The ``.mat`` file contains a dictionary with all of the connectivity measures specified
+by the recon spec for all of the different atlases specified by the user.
+
+For example, in the case where a user has selected a single atlas (``<atlas>``) and
+the recon spec specifies a single connectivity measure (``<measure>``),
+the ``.mat`` file will contain the following keys:
+
+.. code-block::
+
+   command                                # The command that was run
+   atlas_<atlas>_region_ids               # The region ids for the atlas (1 x n_parcels array)
+   atlas_<atlas>_region_labels            # The region labels for the atlas (1 x n_parcels array)
+   atlas_<atlas>_<measure>_connectivity   # The connectivity matrix for the atlas and measure (n_parcels x n_parcels array)
 
 
 **********

--- a/docs/connectivity_matrices.rst
+++ b/docs/connectivity_matrices.rst
@@ -104,6 +104,13 @@ Connectivity Measures
 Connectivity measures are bundled together in binary ``.mat`` files,
 rather than as atlas- and measure-specific tabular files.
 
+.. warning::
+
+   We ultimately plan to organize the connectivity matrices accoring to the BIDS-Connectivity BEP,
+   wherein each measure from each atlas is stored in a separate file.
+
+   Therefore, this organization will change in the future.
+
 .. code-block::
 
    qsirecon/

--- a/qsirecon/interfaces/dsi_studio.py
+++ b/qsirecon/interfaces/dsi_studio.py
@@ -552,7 +552,9 @@ def _sanitized_network_measures(network_txt, official_labels, atlas_name, measur
     assert np.all(truncated_labels == network_region_ids)
 
     for net_measure_name, net_measure_data in network_data.items():
-        variable_name = f"atlas_{atlas_name}_{measure}_{net_measure_name}"
+        net_measure_name = net_measure_name.replace("-", "_")
+        measure_name = measure.replace("-", "_")
+        variable_name = f"atlas_{atlas_name}_{measure_name}_{net_measure_name}"
         if type(net_measure_data) is np.ndarray:
             tmp = np.zeros(n_atlas_labels)
             tmp[in_this_mask] = net_measure_data

--- a/qsirecon/interfaces/dsi_studio.py
+++ b/qsirecon/interfaces/dsi_studio.py
@@ -334,15 +334,15 @@ class DSIStudioConnectivityMatrix(CommandLine):
         # Aggregate the connectivity/network data from DSI Studio
         official_labels = atlas_labels_df["index"].values.astype(int)
         connectivity_data = {
-            f"{atlas_name}_region_ids": official_labels,
-            f"{atlas_name}_region_labels": atlas_labels_df["label"].values,
+            f"atlas_{atlas_name}_region_ids": official_labels,
+            f"atlas_{atlas_name}_region_labels": atlas_labels_df["label"].values,
         }
 
         # Gather the connectivity matrices
         matfiles = glob(op.join(runtime.cwd, "*.connectivity.mat"))
         for matfile in matfiles:
             measure = "_".join(matfile.split(".")[-4:-2])
-            connectivity_data[f"{atlas_name}_{measure}_connectivity"] = (
+            connectivity_data[f"atlas_{atlas_name}_{measure}_connectivity"] = (
                 _sanitized_connectivity_matrix(matfile, official_labels)
             )
 
@@ -552,7 +552,7 @@ def _sanitized_network_measures(network_txt, official_labels, atlas_name, measur
     assert np.all(truncated_labels == network_region_ids)
 
     for net_measure_name, net_measure_data in network_data.items():
-        variable_name = atlas_name + "_" + measure + "_" + net_measure_name
+        variable_name = f"atlas_{atlas_name}_{measure}_{net_measure_name}"
         if type(net_measure_data) is np.ndarray:
             tmp = np.zeros(n_atlas_labels)
             tmp[in_this_mask] = net_measure_data

--- a/qsirecon/interfaces/mrtrix.py
+++ b/qsirecon/interfaces/mrtrix.py
@@ -744,13 +744,13 @@ class BuildConnectome(MRTrix3Base):
 
         # Aggregate the connectivity/network data from DSI Studio
         connectivity_data = {
-            f"{atlas_name}_region_ids": atlas_labels_df["index"].values.astype(int),
-            f"{atlas_name}_region_labels": atlas_labels_df["label"].values,
+            f"atlas_{atlas_name}_region_ids": atlas_labels_df["index"].values.astype(int),
+            f"atlas_{atlas_name}_region_labels": atlas_labels_df["label"].values,
         }
 
         # get the connectivity matrix
         prefix = f"{atlas_name}_{self.inputs.measure}"
-        connectivity_data[f"{prefix}_connectivity"] = np.loadtxt(
+        connectivity_data[f"atlas_{prefix}_connectivity"] = np.loadtxt(
             self.inputs.out_file, delimiter=","
         )
         connectivity_data["command"] = self.cmdline

--- a/qsirecon/workflows/recon/anatomical.py
+++ b/qsirecon/workflows/recon/anatomical.py
@@ -148,6 +148,7 @@ def init_highres_recon_anatomical_wf(
                 seg="hsvs",
                 space="fsnative",
                 suffix="probseg",
+                extension=".mif.gz",
                 compress=True,
             ),
             name="ds_fs_5tt_hsvs",


### PR DESCRIPTION
Closes #164.

## Changes proposed in this pull request

- Add "atlas_" prefix to field names in connectivity MAT files. This will ensure that no fields start with a number (e.g., an atlas name that starts with a number, like 4S*), which is an issue for MATLAB.
- Replace dashes with underscores in measure names. This should change `small-worldness` to `small_worldness`.

## Documentation to review

- https://qsirecon--166.org.readthedocs.build/en/166/connectivity_matrices.html