### PR TITLE
[ENH] update hbcd to exclude noddi

### DIFF
--- a/docs/nonscalars/mrtrix_anat.csv
+++ b/docs/nonscalars/mrtrix_anat.csv
@@ -1,2 +1,2 @@
-\*space-T1w\*atlas-hsvs\*_dseg.nii.gz,Hybrid Surface/Voume Segmentation in MRtrix3 5tt format. Aligned in coordinate space to ``space-T1w``. 
-\*space-fsnative\*atlas-hsvs\*_dseg.nii.gz,Hybrid Surface/Voume Segmentation in MRtrix3 5tt format. Aligned to the FreeSurfer ``orig.mgz`` image.
+\*space-T1w\*seg-hsvs\*_dseg.nii.gz,Hybrid Surface/Voume Segmentation in MRtrix3 5tt format. Aligned in coordinate space to ``space-T1w``. 
+\*space-fsnative\*seg-hsvs\*_dseg.nii.gz,Hybrid Surface/Voume Segmentation in MRtrix3 5tt format. Aligned to the FreeSurfer ``orig.mgz`` image.

--- a/docs/nonscalars/mrtrix_dwi.csv
+++ b/docs/nonscalars/mrtrix_dwi.csv
@@ -1,5 +1,5 @@
 \*_connectivity.mat,MATLAB format mat file containing connectivity matrices for all the selected atlases. This is an hdf5-format file and can be read using ``scipy.io.matlab.loadmat`` in Python. 
-\*_exemplarbundles.zip,A zip archive containing the output directory from ``connectome2tck``. Unzip this directory and view the exemplar connections using ``mrview`` to ensure that you're seeing the expected shapes of connections. 
+\*_exemplarbundles.zip,A zip archive containing the output directory from ``connectome2tck``. Unzip this directory and view the exemplar connections (one is created for each nonzero edge in the connectivity matrix) using ``mrview`` to ensure that you're seeing the expected shapes of connections. 
 \*_streamlines.tck.gz,Streamlines produced by ``tckgen``. NOTE: these are not saved to the output directory by default. 
 \*model-mtnorm\*param-inliermask\*_dwimap.nii.gz,Inlier mask created by ``mtnormalize``
 \*model-mtnorm\*param-norm\*_dwimap.nii.gz,Inlier mask created by ``mtnormalize``

--- a/docs/recon_scalars/dsi_studio_gqi.csv
+++ b/docs/recon_scalars/dsi_studio_gqi.csv
@@ -1,12 +1,12 @@
 gqi,gfa,Generalized Fractional Anisotropy
-gqi,iso,Isotropic Diffusion
-gqi,qa,Fractional Anisotropy from a tensor fit
+gqi,iso,Isotropic Diffusion from GQI
+gqi,qa,Quantitative Anisotropy from a GQI fit
 rdi,rd1,RD1
 rdi,rd2,RD2
-tensor,ad,AD
+tensor,ad,Apparent Diffusivity from a tensor fit
 tensor,fa,Radial Diffusivity from a tensor fit
-tensor,ha,HA
-tensor,md,Mean Diffusivity
+tensor,ha,Helix Angle from tensor fit
+tensor,md,Mean Diffusivity from a tensor fit
 tensor,rd,Radial Diffusivity
 tensor,txx,Tensor fit txx
 tensor,txy,Tensor fit txy

--- a/docs/recon_scalars/hbcd_scalar_maps.csv
+++ b/docs/recon_scalars/hbcd_scalar_maps.csv
@@ -7,8 +7,8 @@ dki,mkt,DKI MKT
 dki,rd,DKI RD
 dki,rk,DKI RK
 gqi,gfa,Generalized Fractional Anisotropy
-gqi,iso,Isotropic Diffusion
-gqi,qa,Fractional Anisotropy from a tensor fit
+gqi,iso,Isotropic Diffusion from GQI
+gqi,qa,Quantitative Anisotropy from a GQI fit
 mapmri,ng,Non-Gaussianity from MAPMRI
 mapmri,ngpar,Non-Gaussianity parallel from MAPMRI
 mapmri,ngperp,Non-Gaussianity perpendicular from MAPMRI
@@ -17,20 +17,16 @@ mapmri,path,PAth from MAPMRI
 mapmri,rtap,Return to axis probability from MAPMRI
 mapmri,rtop,Return to origin probability from MAPMRI
 mapmri,rtpp,Return to plane probability from MAPMRI
-noddi,direction,Peak directions from NODDI
-noddi,icvf,Intracellular volume fraction from NODDI
-noddi,isovf,Isotropic volume fraction from NODDI
-noddi,od,Orientation dispersion index from NODDI
 rdi,rd1,RD1
 rdi,rd2,RD2
-tensor,ad,AD
+tensor,ad,Apparent Diffusivity from a tensor fit
 tensor,am,A0 from a tensor fit
 tensor,fa,DKI FA
 tensor,fa,Fractional Anisotropy from a tensor fit
 tensor,fa,Radial Diffusivity from a tensor fit
-tensor,ha,HA
+tensor,ha,Helix Angle from tensor fit
 tensor,li,LI from a tensor fit
-tensor,md,Mean Diffusivity
+tensor,md,Mean Diffusivity from a tensor fit
 tensor,rd,Radial Diffusivity
 tensor,txx,Tensor fit txx
 tensor,txy,Tensor fit txy

--- a/docs/update_scalardefs.py
+++ b/docs/update_scalardefs.py
@@ -34,8 +34,7 @@ scalars_to_csv(recon_scalars.dipy_mapmri_scalars, "recon_scalars/dipy_mapmri.csv
 scalars_to_csv(recon_scalars.dsistudio_scalars, "recon_scalars/dsi_studio_gqi.csv")
 ## hbcd_scalar_maps.yaml
 scalars_to_csv(
-    recon_scalars.amico_scalars
-    | recon_scalars.dipy_dki_scalars
+    recon_scalars.dipy_dki_scalars
     | recon_scalars.tortoise_scalars
     | recon_scalars.dsistudio_scalars,
     "recon_scalars/hbcd_scalar_maps.csv",

--- a/qsirecon/data/pipelines/hbcd_scalar_maps.yaml
+++ b/qsirecon/data/pipelines/hbcd_scalar_maps.yaml
@@ -35,15 +35,6 @@ nodes:
         small_delta: null
     qsirecon_suffix: TORTOISE_model-tensor
     software: TORTOISE
--   action: fit_noddi
-    input: qsirecon
-    name: fit_noddi
-    parameters:
-        dIso: 0.003
-        dPar: 0.0017
-        isExvivo: false
-    qsirecon_suffix: NODDI
-    software: AMICO
 -   action: reconstruction
     input: qsirecon
     name: dsistudio_gqi
@@ -72,7 +63,6 @@ nodes:
     scalars_from:
     - gqi_scalars
     - dipy_dki
-    - fit_noddi
     - tortoise_fullshell_tensor
     - tortoise_dtmapmri
     software: qsirecon
@@ -84,7 +74,6 @@ nodes:
     scalars_from:
     - gqi_scalars
     - dipy_dki
-    - fit_noddi
     - tortoise_fullshell_tensor
     - tortoise_dtmapmri
     software: qsirecon


### PR DESCRIPTION
The constants in NODDI may not be appropriate for infants, so we are removing NODDI from the hbcd_scalar_maps recon spec.

Documentation is also updated for other recon workflows