### PR TITLE
Fix extension in ds_qsiprep_5tt_hsvs

### DIFF
--- a/qsirecon/workflows/recon/anatomical.py
+++ b/qsirecon/workflows/recon/anatomical.py
@@ -137,6 +137,7 @@ def init_highres_recon_anatomical_wf(
                 seg="hsvs",
                 space="T1w",
                 suffix="probseg",
+                extension=".nii.gz",
                 compress=True,
             ),
             name="ds_qsiprep_5tt_hsvs",


### PR DESCRIPTION
Followup from #165, fixing a related bug flagged by @araikes.

## Changes proposed in this pull request

- Specify extension in `ds_qsiprep_5tt_hsvs` because it was defaulting to an invalid extension (. long_5tt_hdrxform.nii.gz).
