### PR TITLE
Use abspaths for the ODF plotter

### DIFF
--- a/qsirecon/cli/recon_plot.py
+++ b/qsirecon/cli/recon_plot.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 import os
+from pathlib import Path
 import sys
 import warnings
 from argparse import ArgumentParser, RawTextHelpFormatter
@@ -42,53 +43,46 @@ def recon_plot():
     )
 
     parser.add_argument(
-        "--fib", action="store", type=os.path.abspath, help="DSI Studio fib file to convert"
+        "--fib", action="store", help="DSI Studio fib file to convert"
     )
     parser.add_argument(
-        "--mif", type=os.path.abspath, action="store", help="path to a MRtrix mif file"
+        "--mif", action="store", help="path to a MRtrix mif file"
     )
     parser.add_argument(
         "--amplitudes",
-        type=os.path.abspath,
         action="store",
         help="4D ampliudes corresponding to --directions",
     )
     parser.add_argument(
         "--directions",
-        type=os.path.abspath,
         action="store",
         help="text file of directions corresponding to --amplitudes",
     )
     parser.add_argument(
         "--mask_file",
         action="store",
-        type=os.path.abspath,
         help="a NIfTI-1 format file defining a brain mask.",
     )
     parser.add_argument(
         "--odf_rois",
         action="store",
-        type=os.path.abspath,
         help="a NIfTI-1 format file with ROIs for plotting ODFs",
     )
     parser.add_argument(
         "--peaks_image",
         action="store",
         default="peaks_mosiac.png",
-        type=os.path.abspath,
         help="png file for odf peaks image",
     )
     parser.add_argument(
         "--odfs_image",
         action="store",
         default="odfs_mosaic.png",
-        type=os.path.abspath,
         help="png file for odf results",
     )
     parser.add_argument(
         "--background_image",
         action="store",
-        type=os.path.abspath,
         help="a NIfTI-1 format file with a valid q/sform.",
     )
     parser.add_argument(
@@ -100,6 +94,9 @@ def recon_plot():
     parser.add_argument("--ncuts", type=int, default=3, help="number of slices to plot")
     parser.add_argument("--padding", type=int, default=10, help="number of slices to plot")
     opts = parser.parse_args()
+    peaks_png = str(Path(opts.peaks_image).absolute())
+    cwd = os.getcwd()
+    LOGGER.info(f"Running in {cwd}")
 
     if opts.mif:
         odf_img, directions = mif2amps(opts.mif, os.getcwd())
@@ -150,11 +147,12 @@ def recon_plot():
         sys.exit(1)
 
     try:
+        LOGGER.info("Plotting ODF Peaks images...")
         peak_slice_series(
             odf_4d,
             sphere,
             background_data,
-            opts.peaks_image,
+            peaks_png,
             n_cuts=opts.ncuts,
             mask_image=opts.mask_file,
             padding=opts.padding,
@@ -163,16 +161,18 @@ def recon_plot():
         LOGGER.warning(exc)
         sys.exit(1)
 
-    LOGGER.info("saving peaks image to %s", opts.peaks_image)
+    LOGGER.info(f"Saved peaks image to {peaks_png}")
 
     # Plot ODFs in interesting regions
     if opts.odf_rois and not opts.peaks_only:
+        odfs_png_file = str(Path(opts.odfs_image).absolute())
         try:
+            LOGGER.info("Attempting to render ODFs...")
             odf_roi_plot(
                 odf_4d,
                 sphere,
                 background_data,
-                opts.odfs_image,
+                odfs_png_file,
                 opts.odf_rois,
                 subtract_iso=opts.subtract_iso,
                 mask=opts.mask_file,
@@ -181,7 +181,7 @@ def recon_plot():
             LOGGER.warning(exc)
             sys.exit(1)
 
-        LOGGER.info("saved odfs image to %s", opts.odfs_image)
+        LOGGER.info(f"Saved odfs image to {odfs_png_file}")
 
     display.stop()
     sys.exit(0)

--- a/qsirecon/cli/recon_plot.py
+++ b/qsirecon/cli/recon_plot.py
@@ -178,6 +178,8 @@ def recon_plot():
             sys.exit(1)
 
         LOGGER.info(f"Saved odfs image to {odfs_png_file}")
+    else:
+        LOGGER.info("Not plotting ODFs.")
 
     display.stop()
     sys.exit(0)

--- a/qsirecon/cli/recon_plot.py
+++ b/qsirecon/cli/recon_plot.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
 import os
-from pathlib import Path
 import sys
 import warnings
 from argparse import ArgumentParser, RawTextHelpFormatter
+from pathlib import Path
 
 import nibabel as nb
 import numpy as np
@@ -42,12 +42,8 @@ def recon_plot():
         formatter_class=RawTextHelpFormatter,
     )
 
-    parser.add_argument(
-        "--fib", action="store", help="DSI Studio fib file to convert"
-    )
-    parser.add_argument(
-        "--mif", action="store", help="path to a MRtrix mif file"
-    )
+    parser.add_argument("--fib", action="store", help="DSI Studio fib file to convert")
+    parser.add_argument("--mif", action="store", help="path to a MRtrix mif file")
     parser.add_argument(
         "--amplitudes",
         action="store",

--- a/qsirecon/interfaces/reports.py
+++ b/qsirecon/interfaces/reports.py
@@ -276,9 +276,10 @@ class _ReconPeaksReportInputSpec(CommandLineInputSpec):
 
 XVFB_ERROR = """
 
-ODF/Peak Plotting did not produce the expected outputs.
-This could be due to how QSIRecon was run as a container.
+ODF/Peak Plotting did not produce the expected output:
+  {}
 
+This could be due to how QSIRecon was run as a container.
 
 If you ran Singularity/Apptainer with --containall, please also use --writable-tmpfs
 
@@ -299,16 +300,20 @@ class CLIReconPeaksReport(CommandLine):
         outputs = self.output_spec().get()
         workdir = Path(".")
 
+        # There will always be a peak report
         peaks_file = workdir / self.inputs.peak_report
         if not peaks_file.exists():
-            raise Exception(XVFB_ERROR)
+            raise Exception(XVFB_ERROR.format(peaks_file))
         outputs["peak_report"] = str(peaks_file.absolute())
-        if self.inputs.peaks_only:
+
+        # If there will be no ODF report, we are done
+        if self.inputs.peaks_only or not isdefined(self.inputs.odf_rois):
             return outputs
 
+        # Find the ODF report
         odfs_file = workdir / self.inputs.odf_report
         if not odfs_file.exists():
-            raise Exception(XVFB_ERROR)
+            raise Exception(XVFB_ERROR.format(odfs_file))
         outputs["odf_report"] = str(odfs_file.absolute())
 
         return outputs

--- a/qsirecon/interfaces/reports.py
+++ b/qsirecon/interfaces/reports.py
@@ -283,13 +283,6 @@ class CLIReconPeaksReport(CommandLine):
     output_spec = _ReconPeaksReportOutputSpec
     _cmd = "recon_plot"
 
-    def _list_outputs(self):
-        outputs = self.output_spec().get()
-        outputs["peak_report"] = op.abspath(self.inputs.peak_report)
-        if not self.inputs.peaks_only:
-            outputs["odf_report"] = op.abspath(self.inputs.odf_report)
-        return outputs
-
 
 class _ConnectivityReportInputSpec(BaseInterfaceInputSpec):
     connectivity_matfile = File(exists=True)

--- a/qsirecon/interfaces/reports.py
+++ b/qsirecon/interfaces/reports.py
@@ -303,7 +303,7 @@ class CLIReconPeaksReport(CommandLine):
         # There will always be a peak report
         peaks_file = workdir / self.inputs.peak_report
         if not peaks_file.exists():
-            raise Exception(XVFB_ERROR.format(peaks_file))
+            raise Exception(XVFB_ERROR.format(peaks_file.absolute()))
         outputs["peak_report"] = str(peaks_file.absolute())
 
         # If there will be no ODF report, we are done
@@ -313,7 +313,7 @@ class CLIReconPeaksReport(CommandLine):
         # Find the ODF report
         odfs_file = workdir / self.inputs.odf_report
         if not odfs_file.exists():
-            raise Exception(XVFB_ERROR.format(odfs_file))
+            raise Exception(XVFB_ERROR.format(odfs_file.absolute()))
         outputs["odf_report"] = str(odfs_file.absolute())
 
         return outputs


### PR DESCRIPTION
Closes #118 
@araikes noticed that the ODF plotter might be attempting to write out the pngs into the user's home directory. This PR forces the plotter to store images in the runtime working directory