### PR TITLE
Switch hbcd pipeline back to Chen

### DIFF
--- a/qsirecon/data/pipelines/hbcd_scalar_maps.yaml
+++ b/qsirecon/data/pipelines/hbcd_scalar_maps.yaml
@@ -1,6 +1,8 @@
 anatomical: []
 name: hbcd_postproc_beta
+space: T1w
 nodes:
+
 -   action: DKI_reconstruction
     input: qsirecon
     name: dipy_dki
@@ -9,6 +11,7 @@ nodes:
         write_mif: false
     qsirecon_suffix: DIPYDKI
     software: Dipy
+
 -   action: estimate
     input: qsirecon
     name: tortoise_dtmapmri
@@ -23,6 +26,7 @@ nodes:
         small_delta: null
     qsirecon_suffix: TORTOISE_model-MAPMRI
     software: TORTOISE
+
 -   action: estimate
     input: qsirecon
     name: tortoise_fullshell_tensor
@@ -35,6 +39,7 @@ nodes:
         small_delta: null
     qsirecon_suffix: TORTOISE_model-tensor
     software: TORTOISE
+
 -   action: reconstruction
     input: qsirecon
     name: dsistudio_gqi
@@ -42,21 +47,25 @@ nodes:
         method: gqi
     qsirecon_suffix: DSIStudio
     software: DSI Studio
+
 -   action: autotrack
     input: dsistudio_gqi
     name: autotrackgqi
     parameters:
+        dsi_studio_version: chen
         tolerance: 22,26,30
-        track_id: Association,Projection,Commissure,Cerebellum,CranialNerve
+        track_id: Association,Projection,Commissure,Cerebellum
         track_voxel_ratio: 2.0
         yield_rate: 1.0e-06
     qsirecon_suffix: DSIStudio
     software: DSI Studio
+
 -   action: export
     input: dsistudio_gqi
     name: gqi_scalars
     qsirecon_suffix: DSIStudio
     software: DSI Studio
+
 -   action: bundle_map
     input: autotrackgqi
     name: bundle_means
@@ -66,6 +75,7 @@ nodes:
     - tortoise_fullshell_tensor
     - tortoise_dtmapmri
     software: qsirecon
+
 -   action: template_map
     input: qsirecon
     name: template_map
@@ -77,4 +87,4 @@ nodes:
     - tortoise_fullshell_tensor
     - tortoise_dtmapmri
     software: qsirecon
-space: T1w
+

--- a/qsirecon/interfaces/dsi_studio.py
+++ b/qsirecon/interfaces/dsi_studio.py
@@ -880,9 +880,15 @@ def btable_from_bvals_bvecs(bval_file, bvec_file, output_file):
         btablef.write("\n".join(rows) + "\n")
 
 
-def _get_dsi_studio_bundles(desired_bundles=""):
+def _get_dsi_studio_bundles(desired_bundles="", version="hou"):
 
-    dsi_studio_exe = which("dsi_studio")
+    if version == "hou":
+        dsi_studio_exe = which("dsi_studio")
+    elif version == "chen":
+        dsi_studio_exe = which("dsi_studio_chen")
+    else:
+        raise Exception(f"Unrecognized version of DSI Studio. Must be hou or chen, got {version}")
+
     if not dsi_studio_exe:
         raise Exception("No dsi_studio executable found in $PATH")
     bundle_dir = op.split(dsi_studio_exe)[0]
@@ -935,6 +941,6 @@ def _get_dsi_studio_bundles(desired_bundles=""):
         else:
             matching_bundles = get_bundles(bundle)
             if not matching_bundles:
-                LOGGER.warn("No matching bundles found for " + bundle)
+                LOGGER.warning("No matching bundles found for " + bundle)
             bundles_to_track.extend(matching_bundles)
     return bundles_to_track

--- a/qsirecon/workflows/recon/dsi_studio.py
+++ b/qsirecon/workflows/recon/dsi_studio.py
@@ -396,7 +396,9 @@ def init_dsi_studio_autotrack_wf(
     )
     model_name = params.pop("model", "gqi")
     omp_nthreads = config.nipype.omp_nthreads
-    bundle_names = _get_dsi_studio_bundles(params.get("track_id", ""))
+    dsi_studio_version = params.pop("dsi_studio_version", "hou")
+
+    bundle_names = _get_dsi_studio_bundles(params.get("track_id", ""), version=dsi_studio_version)
     bundle_desc = (
         "AutoTrack attempted to reconstruct the following bundles:\n  * "
         + "\n  * ".join(bundle_names)
@@ -406,8 +408,6 @@ def init_dsi_studio_autotrack_wf(
 
     workflow = Workflow(name=name)
     workflow.__desc__ = desc + bundle_desc
-
-    dsi_studio_version = params.pop("dsi_studio_version", "hou")
 
     _AutoTrack = AutoTrack if dsi_studio_version == "hou" else ChenAutoTrack
 


### PR DESCRIPTION
The Hou version of DSI Studio wasn't finding bundles in infant data. This PR switches the `hbcd_scalar_maps` back to using the Chen version.

I don't recommend switching back to Chen for all autotrack runs - we've been testing the Hou version and it looks good. But for infant data only Chen works at the moment