### PR TITLE
Add `smoothing` and `otsu_threshold` autotrack arguments

### DIFF
--- a/qsirecon/interfaces/dsi_studio.py
+++ b/qsirecon/interfaces/dsi_studio.py
@@ -732,7 +732,7 @@ class _AutoTrackInputSpec(DSIStudioCommandLineInputSpec):
         0.6,
         usedefault=False,
         argstr="--otsu_threshold=%.10f",
-        desc="The ratio of otsu threshold to derive default anisotropy threshold."
+        desc="The ratio of otsu threshold to derive default anisotropy threshold.",
     )
     _boilerplate_traits = [
         "track_id",

--- a/qsirecon/interfaces/dsi_studio.py
+++ b/qsirecon/interfaces/dsi_studio.py
@@ -722,6 +722,13 @@ class _AutoTrackInputSpec(DSIStudioCommandLineInputSpec):
     template = traits.Int(
         0, usedefault=True, argstr="--template=%d", desc="Must be 0 for autotrack"
     )
+    smoothing = traints.Float(
+        0, usedefault=False, argstr="--smoothing=%.10f", desc="Smoothing"
+    )
+    otsu_threshold = traints.Float(
+        0.6, usedefault=False, argstr="--otsu_threshold=%.10f",
+        desc="The ratio of otsu threshold to derive default anisotropy threshold."
+    )
     _boilerplate_traits = [
         "track_id",
         "track_voxel_ratio",

--- a/qsirecon/interfaces/dsi_studio.py
+++ b/qsirecon/interfaces/dsi_studio.py
@@ -726,7 +726,7 @@ class _AutoTrackInputSpec(DSIStudioCommandLineInputSpec):
         0,
         usedefault=False,
         argstr="--smoothing=%.10f",
-        desc="Smoothing"
+        desc="Smoothing",
     )
     otsu_threshold = traits.Float(
         0.6,

--- a/qsirecon/interfaces/dsi_studio.py
+++ b/qsirecon/interfaces/dsi_studio.py
@@ -722,11 +722,16 @@ class _AutoTrackInputSpec(DSIStudioCommandLineInputSpec):
     template = traits.Int(
         0, usedefault=True, argstr="--template=%d", desc="Must be 0 for autotrack"
     )
-    smoothing = traints.Float(
-        0, usedefault=False, argstr="--smoothing=%.10f", desc="Smoothing"
+    smoothing = traits.Float(
+        0,
+        usedefault=False,
+        argstr="--smoothing=%.10f",
+        desc="Smoothing"
     )
-    otsu_threshold = traints.Float(
-        0.6, usedefault=False, argstr="--otsu_threshold=%.10f",
+    otsu_threshold = traits.Float(
+        0.6,
+        usedefault=False,
+        argstr="--otsu_threshold=%.10f",
         desc="The ratio of otsu threshold to derive default anisotropy threshold."
     )
     _boilerplate_traits = [

--- a/qsirecon/workflows/recon/dsi_studio.py
+++ b/qsirecon/workflows/recon/dsi_studio.py
@@ -377,6 +377,20 @@ def init_dsi_studio_autotrack_wf(
             This rate will be used to terminate tracking early if DSI Studio finds that the
             fiber tracking is not generating results. (default: 0.00001)
 
+        smoothing: float
+            Smoothing serves like a “momentum”. For example, if smoothing is 0, the 
+            propagation direction is independent of the previous incoming direction. 
+            If the smoothing is 0.5, each moving direction remains 50% of the “momentum”,
+            which is the previous propagation vector. This function makes the tracks 
+            appear smoother. In implementation detail, there is a weighting sum on every
+            two consecutive moving directions. For smoothing value 0.2, each subsequent
+            direction has 0.2 weightings contributed from the previous moving direction 
+            and 0.8 contributed from the income direction. To disable smoothing set 
+            its value to 0. Assign 1.0 to do a random selection of the value from 0% to 95%.
+
+        otsu_threshold: float
+            The ratio of otsu threshold to derive default anisotropy threshold.
+
         model_name: str
             The name of the model used for ODFs (default "gqi")
     """

--- a/qsirecon/workflows/recon/dsi_studio.py
+++ b/qsirecon/workflows/recon/dsi_studio.py
@@ -378,14 +378,14 @@ def init_dsi_studio_autotrack_wf(
             fiber tracking is not generating results. (default: 0.00001)
 
         smoothing: float
-            Smoothing serves like a “momentum”. For example, if smoothing is 0, the 
-            propagation direction is independent of the previous incoming direction. 
+            Smoothing serves like a “momentum”. For example, if smoothing is 0, the
+            propagation direction is independent of the previous incoming direction.
             If the smoothing is 0.5, each moving direction remains 50% of the “momentum”,
-            which is the previous propagation vector. This function makes the tracks 
+            which is the previous propagation vector. This function makes the tracks
             appear smoother. In implementation detail, there is a weighting sum on every
             two consecutive moving directions. For smoothing value 0.2, each subsequent
-            direction has 0.2 weightings contributed from the previous moving direction 
-            and 0.8 contributed from the income direction. To disable smoothing set 
+            direction has 0.2 weightings contributed from the previous moving direction
+            and 0.8 contributed from the income direction. To disable smoothing set
             its value to 0. Assign 1.0 to do a random selection of the value from 0% to 95%.
 
         otsu_threshold: float


### PR DESCRIPTION
Closes None, but allows for more flexible autotrack runs.