### PR TITLE
Add unit metadata to some scalar maps

### DIFF
--- a/qsirecon/data/scalars/dipy_dki.yaml
+++ b/qsirecon/data/scalars/dipy_dki.yaml
@@ -4,7 +4,7 @@ dki_ad:
         param: ad
     metadata:
         Description: DKI axial diffusivity
-        Units: μm^2/ms
+        Units: mm^2/s
 dki_ak:
     bids:
         model: dki

--- a/qsirecon/data/scalars/dsistudio_gqi.yaml
+++ b/qsirecon/data/scalars/dsistudio_gqi.yaml
@@ -4,7 +4,7 @@ ad_file:
         param: ad
     metadata:
         Description: Axial Diffusivity from a tensor fit. The first eigenvalue of the tensor.
-        Units: mm^2/s
+        Units: μm^2/ms
 dti_fa_file:
     bids:
         model: tensor
@@ -35,6 +35,7 @@ md_file:
         param: md
     metadata:
         Description: Mean Diffusivity from a tensor fit. The mean of the three eigenvalues.
+        Units: μm^2/ms
 qa_file:
     bids:
         model: gqi
@@ -47,18 +48,21 @@ rd1_file:
         param: rd1
     metadata:
         Description: Lambda 2 (second eigenvalue) from a tensor fit.
+        Units: μm^2/ms
 rd2_file:
     bids:
         model: tensor
         param: rd2
     metadata:
         Description: Lambda 3 (third eigenvalue) from a tensor fit.
+        Units: μm^2/ms
 rd_file:
     bids:
         model: tensor
         param: rd
     metadata:
         Description: Radial Diffusivity from a tensor fit. The mean of the second and third eigenvalues (rd1 and rd2).
+        Units: μm^2/ms
 txx_file:
     bids:
         model: tensor


### PR DESCRIPTION
Relates to #229.

## Changes proposed in this pull request

- Add Units field to sidecar files for DIPY DKI AD and DSIStudio AD scalar maps.