### PR TITLE
Remove background label from atlases before calculating connectivity

### DIFF
--- a/qsirecon/interfaces/dsi_studio.py
+++ b/qsirecon/interfaces/dsi_studio.py
@@ -339,8 +339,13 @@ class DSIStudioConnectivityMatrix(CommandLine):
         atlas_name = self.inputs.atlas_name
         atlas_labels_df = pd.read_table(self.inputs.atlas_labels_file)
 
+        atlas_labels_df["index"] = atlas_labels_df["index"].astype(int)
+        if 0 in atlas_labels_df["index"].values:
+            print(f"WARNING: Atlas {atlas_name} has a 0 index. This index will be dropped.")
+            atlas_labels_df = atlas_labels_df.loc[atlas_labels_df["index"] != 0]
+
         # Aggregate the connectivity/network data from DSI Studio
-        official_labels = atlas_labels_df["index"].values.astype(int)
+        official_labels = atlas_labels_df["index"].values
         connectivity_data = {
             f"atlas_{atlas_name}_region_ids": official_labels,
             f"atlas_{atlas_name}_region_labels": atlas_labels_df["label"].values,

--- a/qsirecon/interfaces/mrtrix.py
+++ b/qsirecon/interfaces/mrtrix.py
@@ -742,9 +742,14 @@ class BuildConnectome(MRTrix3Base):
         atlas_name = self.inputs.atlas_name
         atlas_labels_df = pd.read_table(self.inputs.atlas_labels_file)
 
+        atlas_labels_df["index"] = atlas_labels_df["index"].astype(int)
+        if 0 in atlas_labels_df["index"].values:
+            print(f"WARNING: Atlas {atlas_name} has a 0 index. This index will be dropped.")
+            atlas_labels_df = atlas_labels_df.loc[atlas_labels_df["index"] != 0]
+
         # Aggregate the connectivity/network data from DSI Studio
         connectivity_data = {
-            f"atlas_{atlas_name}_region_ids": atlas_labels_df["index"].values.astype(int),
+            f"atlas_{atlas_name}_region_ids": atlas_labels_df["index"].values,
             f"atlas_{atlas_name}_region_labels": atlas_labels_df["label"].values,
         }
 

--- a/qsirecon/interfaces/utils.py
+++ b/qsirecon/interfaces/utils.py
@@ -167,6 +167,12 @@ def label_convert(original_atlas, output_mif, orig_txt, mrtrix_txt, atlas_labels
     import pandas as pd
 
     atlas_labels_df = pd.read_table(atlas_labels_file)
+
+    atlas_labels_df["index"] = atlas_labels_df["index"].astype(int)
+    if 0 in atlas_labels_df["index"].values:
+        print(f"WARNING: Atlas {atlas_labels_file} has a 0 index. This index will be dropped.")
+        atlas_labels_df = atlas_labels_df.loc[atlas_labels_df["index"] != 0]
+
     index_label_pairs = zip(atlas_labels_df["index"], atlas_labels_df["label"])
     orig_str = ""
     mrtrix_str = ""


### PR DESCRIPTION
Closes none.

## Changes proposed in this pull request

- In nodes that use the atlas labels file, remove the 0 index (which almost universally corresponds to the background/non-brain).
    - I had to do this within individual interfaces because we don't sanitize atlases in a centralized step.