### PR TITLE
Remove outdated admonition

### DIFF
--- a/docs/builtin_workflows.rst
+++ b/docs/builtin_workflows.rst
@@ -363,11 +363,6 @@ Other Outputs
 
 A DKI model is fit to the dMRI signal and multiple scalar maps are produced.
 
-.. important::
-
-   In order to calculate microstructural metrics with the ``dkimicro`` model,
-   you must set the ``wmti`` flag to ``True``.
-
 Scalar Maps
 -----------
 .. csv-table::


### PR DESCRIPTION
Closes #231.

## Changes proposed in this pull request

- Remove inaccurate admonition about the `dkimicro` option.