### PR TITLE
Use deltas in DIPY interfaces

### DIFF
--- a/qsirecon/data/pipelines/csdsi_3dshore.yaml
+++ b/qsirecon/data/pipelines/csdsi_3dshore.yaml
@@ -6,11 +6,13 @@ nodes:
     input: qsirecon
     name: csdsi_3dshore
     parameters:
+        big_delta: null
         extrapolate_scheme: HCP
         lambdaL: 1.0e-08
         lambdaN: 1.0e-08
         radial_order: 8
         regularization: L2
+        small_delta: null
         write_fibgz: true
         write_mif: true
     qsirecon_suffix: 3dSHORE

--- a/qsirecon/data/pipelines/dipy_3dshore.yaml
+++ b/qsirecon/data/pipelines/dipy_3dshore.yaml
@@ -5,10 +5,12 @@ nodes:
     input: qsirecon
     name: recon_3dshore
     parameters:
+        big_delta: null
         lambdaL: 1.0e-08
         lambdaN: 1.0e-08
         radial_order: 6
         regularization: L2
+        small_delta: null
         tau: 0.025330295910584444
         write_fibgz: true
         write_mif: true

--- a/qsirecon/data/pipelines/dipy_mapmri.yaml
+++ b/qsirecon/data/pipelines/dipy_mapmri.yaml
@@ -6,11 +6,13 @@ nodes:
     name: mapmri_recon
     parameters:
         anisotropic_scaling: false
+        big_delta: null
         bval_threshold: 2000
         dti_scale_estimation: false
         laplacian_regularization: true
         laplacian_weighting: 0.2
         radial_order: 6
+        small_delta: null
         write_fibgz: true
         write_mif: true
     qsirecon_suffix: DIPYMAPMRI

--- a/qsirecon/data/pipelines/multishell_scalarfest.yaml
+++ b/qsirecon/data/pipelines/multishell_scalarfest.yaml
@@ -45,11 +45,13 @@ nodes:
     name: mapmri_recon
     parameters:
         anisotropic_scaling: false
+        big_delta: null
         bval_threshold: 2000
         dti_scale_estimation: false
         laplacian_regularization: true
         laplacian_weighting: 0.2
         radial_order: 6
+        small_delta: null
         write_fibgz: false
         write_mif: false
     qsirecon_suffix: MAPMRI
@@ -68,11 +70,13 @@ nodes:
     input: qsirecon
     name: csdsi_3dshore
     parameters:
+        big_delta: null
         extrapolate_scheme: HCP
         lambdaL: 1.0e-08
         lambdaN: 1.0e-08
         radial_order: 8
         regularization: L2
+        small_delta: null
         write_fibgz: false
         write_mif: false
     qsirecon_suffix: DIPY3dSHORE

--- a/qsirecon/workflows/recon/dipy.py
+++ b/qsirecon/workflows/recon/dipy.py
@@ -153,6 +153,24 @@ def init_dipy_brainsuite_shore_recon_wf(
     plot_reports = not config.execution.skip_odf_reports
     workflow = Workflow(name=name)
     desc = "#### Dipy Reconstruction\n\n"
+
+    # Do we have deltas?
+    deltas = (params.get("big_delta", None), params.get("small_delta", None))
+    approximate_deltas = None in deltas
+    dwi_metadata = inputs_dict.get("dwi_metadata", {})
+    if approximate_deltas:
+        deltas = (
+            dwi_metadata.get("LargeDelta", None),
+            dwi_metadata.get("SmallDelta", None),
+        )
+        approximate_deltas = None in deltas
+
+    # Set deltas if we have them. Prevent only one from being defined
+    if approximate_deltas:
+        LOGGER.warning('Both "big_delta" and "small_delta" are required for precise 3dSHORE')
+    else:
+        params["big_delta"], params["small_delta"] = deltas
+
     recon_shore = pe.Node(BrainSuiteShoreReconstruction(**params), name="recon_shore")
     recon_scalars = pe.Node(
         BrainSuite3dSHOREReconScalars(qsirecon_suffix="name"),
@@ -457,6 +475,24 @@ def init_dipy_mapmri_recon_wf(
 
     workflow = Workflow(name=name)
     desc = "#### Dipy Reconstruction\n\n"
+
+    # Do we have deltas?
+    deltas = (params.get("big_delta", None), params.get("small_delta", None))
+    approximate_deltas = None in deltas
+    dwi_metadata = inputs_dict.get("dwi_metadata", {})
+    if approximate_deltas:
+        deltas = (
+            dwi_metadata.get("LargeDelta", None),
+            dwi_metadata.get("SmallDelta", None),
+        )
+        approximate_deltas = None in deltas
+
+    # Set deltas if we have them. Prevent only one from being defined
+    if approximate_deltas:
+        LOGGER.warning('Both "big_delta" and "small_delta" are required for precise MAPMRI')
+    else:
+        params["big_delta"], params["small_delta"] = deltas
+
     plot_reports = not config.execution.skip_odf_reports
     omp_nthreads = config.nipype.omp_nthreads
     recon_map = pe.Node(MAPMRIReconstruction(**params), name="recon_map")


### PR DESCRIPTION
Closes #227.

## Changes proposed in this pull request

- Extract big_delta/LargeDelta and small_delta/SmallDelta from recon spec or DWI metadata, when available, and pass along to BrainSuiteShoreReconstruction and MAPMRIReconstruction in DIPY workflows.