### PR TITLE
Add unused `plot_reports` input to `_KurtosisReconstructionInputSpec`

### DIFF
--- a/qsirecon/interfaces/dipy.py
+++ b/qsirecon/interfaces/dipy.py
@@ -527,6 +527,7 @@ class TensorReconstruction(DipyReconInterface):
 class _KurtosisReconstructionInputSpec(DipyReconInputSpec):
     kurtosis_clip_min = traits.Float(-0.42857142857142855, usedefault=True)
     kurtosis_clip_max = traits.Float(10.0, usedefault=True)
+    plot_reports = traits.Bool(True, usedefault=True)
 
 
 class _KurtosisReconstructionOutputSpec(DipyReconOutputSpec):
@@ -554,7 +555,7 @@ class KurtosisReconstruction(DipyReconInterface):
         gtab = self._get_gtab()
         dwi_img = nb.load(self.inputs.dwi_file)
         dwi_data = dwi_img.get_fdata(dtype="float32")
-        mask_img, mask_array = self._get_mask(dwi_img, gtab)
+        _, mask_array = self._get_mask(dwi_img, gtab)
 
         # Fit it
         dkimodel = dki.DiffusionKurtosisModel(gtab)


### PR DESCRIPTION
Closes #216.

## Changes proposed in this pull request

- Add `plot_reports` input to `KurtosisReconstruction` interface. This input isn't used, but it allows the workflow to pass in a `plot_reports` attribute through the `params` dictionary without raising an error.