### PR TITLE
Prevent workflow spec dictionary from being modified in place during build process

### DIFF
--- a/qsirecon/tests/test_utils.py
+++ b/qsirecon/tests/test_utils.py
@@ -11,20 +11,20 @@ from qsirecon.data import load as load_data
 
 def test_collect_anatomical_data(tmp_path_factory):
     """Test collect_anatomical_data."""
-    skeleton = load_data('tests/skeletons/longitudinal_anat.yml')
-    bids_dir = tmp_path_factory.mktemp('test_collect_anatomical_data') / 'bids'
+    skeleton = load_data("tests/skeletons/longitudinal_anat.yml")
+    bids_dir = tmp_path_factory.mktemp("test_collect_anatomical_data") / "bids"
     generate_bids_skeleton(str(bids_dir), str(skeleton))
 
     layout = BIDSLayout(
         bids_dir,
         validate=False,
-        config=['bids', 'derivatives'],
+        config=["bids", "derivatives"],
     )
     anat_input_filename = os.path.join(
         bids_dir,
-        'sub-01',
-        'anat',
-        'sub-01_space-ACPC_desc-preproc_T1w.nii.gz',
+        "sub-01",
+        "anat",
+        "sub-01_space-ACPC_desc-preproc_T1w.nii.gz",
     )
     anat_input_file = layout.get_file(anat_input_filename)
 
@@ -38,39 +38,39 @@ def test_collect_anatomical_data(tmp_path_factory):
 
     anat_data, highres_anat_status = xbids.collect_anatomical_data(
         layout=layout,
-        subject_id='01',
+        subject_id="01",
         session_id=_session_filter,
         needs_t1w_transform=False,
         infant_mode=False,
         bids_filters={},
     )
-    assert highres_anat_status['has_qsiprep_t1w'] is True
-    assert highres_anat_status['has_qsiprep_t1w_transforms'] is True
+    assert highres_anat_status["has_qsiprep_t1w"] is True
+    assert highres_anat_status["has_qsiprep_t1w_transforms"] is True
     # These are collected
-    assert anat_data['acpc_preproc'] is not None
-    assert anat_data['acpc_brain_mask'] is not None
-    assert anat_data['acpc_to_template_xfm'] is not None
-    assert anat_data['template_to_acpc_xfm'] is not None
-    assert anat_data['acpc_aseg'] is not None
+    assert anat_data["acpc_preproc"] is not None
+    assert anat_data["acpc_brain_mask"] is not None
+    assert anat_data["acpc_to_template_xfm"] is not None
+    assert anat_data["template_to_acpc_xfm"] is not None
+    assert anat_data["acpc_aseg"] is not None
     # A number of inputs are not collected
-    assert anat_data['acpc_aparc'] is None
-    assert anat_data['acpc_csf_probseg'] is None
-    assert anat_data['acpc_gm_probseg'] is None
-    assert anat_data['acpc_wm_probseg'] is None
+    assert anat_data["acpc_aparc"] is None
+    assert anat_data["acpc_csf_probseg"] is None
+    assert anat_data["acpc_gm_probseg"] is None
+    assert anat_data["acpc_wm_probseg"] is None
     # This should be collected, but is not because the file is in a session folder.
-    assert anat_data['orig_to_acpc_xfm'] is None
+    assert anat_data["orig_to_acpc_xfm"] is None
 
 
 def test_get_iterable_dwis_and_anats(tmp_path_factory):
     """Test get_iterable_dwis_and_anats."""
-    skeleton = load_data('tests/skeletons/longitudinal_anat.yml')
-    bids_dir = tmp_path_factory.mktemp('test_get_iterable_dwis_and_anats') / 'bids'
+    skeleton = load_data("tests/skeletons/longitudinal_anat.yml")
+    bids_dir = tmp_path_factory.mktemp("test_get_iterable_dwis_and_anats") / "bids"
     generate_bids_skeleton(str(bids_dir), str(skeleton))
 
     layout = BIDSLayout(
         bids_dir,
         validate=False,
-        config=['bids', 'derivatives'],
+        config=["bids", "derivatives"],
     )
     dwis_and_anats = xbids.get_iterable_dwis_and_anats(layout=layout)
     assert len(dwis_and_anats) == 1

--- a/qsirecon/workflows/recon/build_workflow.py
+++ b/qsirecon/workflows/recon/build_workflow.py
@@ -1,4 +1,5 @@
 """This module contains the functions that build the nipype workflows from the workflow specs."""
+
 from copy import deepcopy
 
 import nipype.pipeline.engine as pe


### PR DESCRIPTION
Closes none, but addresses a bug identified by @ameliecr. When running QSIRecon on multiple sessions within a single job, the first session would work as expected, but subsequent sessions would use default parameters instead of the ones specified in the spec. This appears to stem from modifications made to subdictionaries within the spec by individual nodes via the dictionary `.pop()` method. We didn't realize that the overall dictionary was being modified in place because the LINC lab typically processes sessions within separate jobs.

## Changes proposed in this pull request

- Create a deepcopy of the spec dictionary in the workflow-building workflow before it can be modified.