### PR TITLE
Disable dkimicro/wmti in recon specs

### DIFF
--- a/qsirecon/data/pipelines/dipy_dki.yaml
+++ b/qsirecon/data/pipelines/dipy_dki.yaml
@@ -6,7 +6,7 @@ nodes:
     name: dki_recon
     parameters:
         # Calculate microstructural metrics
-        wmti: true
+        wmti: false
         write_fibgz: false
         write_mif: false
     qsirecon_suffix: DKI

--- a/qsirecon/data/pipelines/hbcd_scalar_maps.yaml
+++ b/qsirecon/data/pipelines/hbcd_scalar_maps.yaml
@@ -8,7 +8,7 @@ nodes:
     name: dipy_dki
     parameters:
         # Calculate microstructural metrics
-        wmti: true
+        wmti: false
         write_fibgz: false
         write_mif: false
     qsirecon_suffix: DIPYDKI

--- a/qsirecon/data/pipelines/multishell_scalarfest.yaml
+++ b/qsirecon/data/pipelines/multishell_scalarfest.yaml
@@ -61,7 +61,7 @@ nodes:
     name: dki_recon
     parameters:
         # Calculate microstructural metrics
-        wmti: true
+        wmti: false
         write_fibgz: false
         write_mif: false
     qsirecon_suffix: DKI

--- a/qsirecon/data/pipelines/test_scalar_maps.yaml
+++ b/qsirecon/data/pipelines/test_scalar_maps.yaml
@@ -6,7 +6,7 @@ nodes:
     name: dipy_dki
     parameters:
         # Calculate microstructural metrics
-        wmti: true
+        wmti: false
         write_fibgz: false
         write_mif: false
     qsirecon_suffix: DIPYDKI


### PR DESCRIPTION
Closes #266.

## Changes proposed in this pull request

- Set `wmti: false` in reconstruction specs.