### PR TITLE
Allow scalar figure vmin/vmax to be percentiles

### DIFF
--- a/qsirecon/data/scalars/amico_noddi.yaml
+++ b/qsirecon/data/scalars/amico_noddi.yaml
@@ -81,7 +81,8 @@ rmse:
             Description: Neurite Orientation Dispersion and Density Imaging (NODDI)
             URL: https://www.sciencedirect.com/science/article/pii/S1053811914008519
     figure:
-        vmin: 0
+        vmin: 0%
+        vmax: 98%
 nrmse:
     bids:
         model: noddi


### PR DESCRIPTION
<!--
Text in these brackets are comments, and won't be visible when you submit your pull request.
If this is your first contribution, please take the time to read these, in particular the comment
beginning "Welcome, new contributors!".
-->

## Changes proposed in this pull request

- Modify `plot_scalar_map` to allow the vmin and vmax values to be percentile strings (e.g., `98%`).
- Change one of the scalar maps' settings to use the new feature.
