### PR TITLE
Set alpha to 0.5 in scalar plots

### DIFF
--- a/qsirecon/interfaces/reports.py
+++ b/qsirecon/interfaces/reports.py
@@ -539,6 +539,7 @@ def plot_scalar_map(
         vmax=xmax,
         axes=ax1,
         cmap=cmap,
+        alpha=0.5,
         **kwargs,
     )
     mappable = cm.ScalarMappable(norm=plt.Normalize(vmin=xmin, vmax=xmax), cmap=cmap)


### PR DESCRIPTION
I was attempting to reproduce @araikes's bug report on a mismatch between the scalar plot underlays (the anatomical image) and the overlays (the scalar maps, which should be in the same space), but it didn't work.

## Changes proposed in this pull request

<!--
Please describe here the main features / changes proposed for review and integration in qsirecon
If this PR addresses some existing problem, please use GitHub's citing tools
(eg. ref #, closes # or fixes #).
If there is not an existing issue open describing the problem, please consider opening a new
issue first and then link it from here (so the *qsirecon* community has a better understanding
of ongoing development efforts and possible overlaps between contributions).
-->


## Documentation that should be reviewed
<!--
Please summarize here the main changes to the documentation that the reviewers should be aware of.
-->



<!--
Welcome, new contributors!

We ask you to read through the Contributing Guide:
https://github.com/pennlinc/qsirecon/blob/main/CONTRIBUTING.md

These are guidelines intended to make communication easier by describing a consistent process, but
don't worry if you don't get it everything exactly "right" on the first try.

To boil it down, here are some highlights:

1) Consider starting a conversation in the issues list before submitting a pull request. The discussion might save you a
   lot of time coding.
2) Please use descriptive prefixes in your pull request title, such as "ENH:" for an enhancement or "FIX:" for a bug fix.
   (See the Contributing guide for the full set.) And consider adding a "WIP" tag for works-in-progress.
3) Any code you submit will be licensed under the same terms (BSD 3-Clause) as the rest of QSIRecon.

A pull request is a conversation. We may ask you to make some changes before accepting your PR,
and likewise, you should feel free to ask us any questions you have.

-->
