### PR TITLE
Add integer downsample option for MRtrix3 tckgen

### DIFF
--- a/qsirecon/interfaces/mrtrix.py
+++ b/qsirecon/interfaces/mrtrix.py
@@ -67,6 +67,7 @@ class TckGenInputSpec(TractographyInputSpec):
             "selected and written to the output file"
         ),
     )
+    downsample = traits.CInt(argstr="-downsample %d")
     n_tracks = traits.Int(desc="NOT supported, do not use")
     quiet = traits.Bool(argstr="-quiet")
 


### PR DESCRIPTION
<!--
Text in these brackets are comments, and won't be visible when you submit your pull request.
If this is your first contribution, please take the time to read these, in particular the comment
beginning "Welcome, new contributors!".
-->

## Changes proposed in this pull request

Add integer downsample option for mrtrix tckgen (Must be a traits.CInt). `tckgen -downsample N` is especially useful when using SD_stream that uses much smaller stepsizes, creating much larger tck files.

<!--
Please describe here the main features / changes proposed for review and integration in qsirecon
If this PR addresses some existing problem, please use GitHub's citing tools
(eg. ref #, closes # or fixes #).
If there is not an existing issue open describing the problem, please consider opening a new
issue first and then link it from here (so the *qsirecon* community has a better understanding
of ongoing development efforts and possible overlaps between contributions).
-->


## Documentation that should be reviewed
<!--
Please summarize here the main changes to the documentation that the reviewers should be aware of.
-->



<!--
Welcome, new contributors!

We ask you to read through the Contributing Guide:
https://github.com/pennlinc/qsirecon/blob/main/CONTRIBUTING.md

These are guidelines intended to make communication easier by describing a consistent process, but
don't worry if you don't get it everything exactly "right" on the first try.

To boil it down, here are some highlights:

1) Consider starting a conversation in the issues list before submitting a pull request. The discussion might save you a
   lot of time coding.
2) Please use descriptive prefixes in your pull request title, such as "ENH:" for an enhancement or "FIX:" for a bug fix.
   (See the Contributing guide for the full set.) And consider adding a "WIP" tag for works-in-progress.
3) Any code you submit will be licensed under the same terms (BSD 3-Clause) as the rest of QSIRecon.

A pull request is a conversation. We may ask you to make some changes before accepting your PR,
and likewise, you should feel free to ask us any questions you have.

-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add `downsample` integer option to MRtrix `TckGen` interface (`-downsample %d`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ed07e4985bedb05ed29db7135064dd2fbba1433c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->