### PR TITLE
Fix: Add missing export action to dsi_studio_autotrack pipeline

### DIFF
--- a/qsirecon/data/pipelines/dsi_studio_autotrack.yaml
+++ b/qsirecon/data/pipelines/dsi_studio_autotrack.yaml
@@ -7,6 +7,11 @@ nodes:
         method: gqi
     qsirecon_suffix: DSIStudio
     software: DSI Studio
+-   action: export
+    input: dsistudio_gqi
+    name: scalar_export
+    qsirecon_suffix: DSIStudio
+    software: DSI Studio
 -   action: autotrack
     input: dsistudio_gqi
     name: autotrackgqi


### PR DESCRIPTION
The dsi_studio_autotrack workflow was not generating scalar maps (gfa, iso, qa, dti_fa, etc.) because the export action was missing from the pipeline configuration.

This commit adds the scalar export step between the GQI reconstruction and the autotrack steps, ensuring that scalar maps are properly generated as documented in the builtin_workflows.rst.

Scalar outputs will now include files like:
- *_desc-gfa_dwimap.nii.gz
- *_desc-iso_dwimap.nii.gz
- *_desc-qa_dwimap.nii.gz
- And additional tensor-derived parameters

Fixes the issue where derivatives only contained streamlines and bundlestats without scalar maps.

Closes #347
