### PR TITLE
Address more difficult linter errors

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -23,7 +23,7 @@
 import os
 import sys
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import datetime, timezone
 
 import sphinxcontrib.bibtex.plugin
 from dipy import __version__ as dipy_version
@@ -106,7 +106,7 @@ master_doc = 'index'
 # General information about the project.
 project = 'qsirecon'
 author = 'qsirecon team'
-copyright = f'2021-{datetime.now().year}, {author}'
+copyright = f'2021-{datetime.now(tz=timezone.utc).year}, {author}'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -392,9 +392,7 @@ texinfo_documents = [
 # The following is used by sphinx.ext.linkcode to provide links to github
 linkcode_resolve = make_linkcode_resolve(
     'qsirecon',
-    (
-        'https://github.com/pennlinc/qsirecon/blob/{revision}/{package}/{path}#L{lineno}'  # noqa: FS003
-    ),
+    'https://github.com/pennlinc/qsirecon/blob/{revision}/{package}/{path}#L{lineno}',
 )
 
 # -----------------------------------------------------------------------------

--- a/docs/update_scalardefs.py
+++ b/docs/update_scalardefs.py
@@ -59,9 +59,9 @@ def output_to_filepattern(bids):
     if 'label' in bids:
         file_pattern.append(f'label-{bids["label"]}')
 
-    extension = bids.get('extension', '\*')
+    extension = bids.get('extension', r'\*')
     file_pattern.append(f'_{bids.get("suffix", "dwimap")}.{extension}')
-    return '\*' + '\*'.join(file_pattern)
+    return r'\*' + r'\*'.join(file_pattern)
 
 
 def outputs_to_csv(output_def, output_csv):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -159,7 +159,6 @@ extend-select = [
   "Q",
 ]
 ignore = [
-  "B905",  # `zip()` without an explicit `strict=` parameter
   "S101",  # Use of `assert` detected
   "S607",  # Starting a process with a partial executable path
   "S608",  # ruff interprets informative error message as potential SQL injection vector

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -169,7 +169,6 @@ ignore = [
   "E402",  # Module level import not at top of file
   "S607",  # Starting a process with a partial executable path
   "B028",  # No explicit `stacklevel` keyword argument found
-  "S202",  # Uses of `tarfile.extractall()`
   "DTZ005",  # `datetime.datetime.now()` called without a `tz` argument
   "DTZ007",  # Naive datetime constructed using `datetime.datetime.strptime()` without %z
   "S608",  # Possible SQL injection vector through string-based query construction

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -166,7 +166,6 @@ ignore = [
   "B905",  # `zip()` without an explicit `strict=` parameter
   "S101",  # Use of `assert` detected
   "W605",  # [*] Invalid escape sequence: `\s`
-  "E402",  # Module level import not at top of file
   "S607",  # Starting a process with a partial executable path
   "DTZ005",  # `datetime.datetime.now()` called without a `tz` argument
   "DTZ007",  # Naive datetime constructed using `datetime.datetime.strptime()` without %z

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -159,7 +159,6 @@ extend-select = [
   "Q",
 ]
 ignore = [
-  "B006",  # Do not use mutable data structures for argument defaults (keep in ignore)
   "S110",  # `try`-`except`-`pass` detected
   "B904",  # Within an `except` clause, raise exceptions
   "BLE001",  # Do not catch blind exceptions

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -159,10 +159,6 @@ extend-select = [
   "Q",
 ]
 ignore = [
-  "S110",  # `try`-`except`-`pass` detected
-  "B904",  # Within an `except` clause, raise exceptions
-  "BLE001",  # Do not catch blind exceptions
-  "B017",  # Do not assert blind exception: `Exception`
   "B905",  # `zip()` without an explicit `strict=` parameter
   "S101",  # Use of `assert` detected
   "S607",  # Starting a process with a partial executable path
@@ -181,6 +177,7 @@ inline-quotes = "single"
 "qsirecon/utils/debug.py" = ["A002", "T100"]
 "docs/conf.py" = ["A001"]
 "docs/sphinxext/github_link.py" = ["BLE001"]
+"docs/sphinxext/qsirecon_apidoc.py" = ["BLE001", "S110"]
 
 [tool.ruff.format]
 quote-style = "single"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -165,7 +165,6 @@ ignore = [
   "B017",  # Do not assert blind exception: `Exception`
   "B905",  # `zip()` without an explicit `strict=` parameter
   "S101",  # Use of `assert` detected
-  "PT027",  # Use `pytest.raises` instead of unittest-style `assertRaises`
   "W605",  # [*] Invalid escape sequence: `\s`
   "E402",  # Module level import not at top of file
   "S607",  # Starting a process with a partial executable path

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -165,7 +165,6 @@ ignore = [
   "B017",  # Do not assert blind exception: `Exception`
   "B905",  # `zip()` without an explicit `strict=` parameter
   "S101",  # Use of `assert` detected
-  "W605",  # [*] Invalid escape sequence: `\s`
   "S607",  # Starting a process with a partial executable path
   "DTZ005",  # `datetime.datetime.now()` called without a `tz` argument
   "DTZ007",  # Naive datetime constructed using `datetime.datetime.strptime()` without %z

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -159,7 +159,6 @@ extend-select = [
   "Q",
 ]
 ignore = [
-  "S101",  # Use of `assert` detected
   "S607",  # Starting a process with a partial executable path
   "S608",  # ruff interprets informative error message as potential SQL injection vector
   "S108",  # Probable insecure usage of temporary file or directory: "/tmp"
@@ -172,7 +171,8 @@ ignore = [
 inline-quotes = "single"
 
 [tool.ruff.lint.extend-per-file-ignores]
-"*/test_*.py" = ["S101"]
+"qsirecon/tests/*.py" = ["S101"]
+"qsirecon/utils/testing.py" = ["S101"]
 "qsirecon/utils/debug.py" = ["A002", "T100"]
 "docs/conf.py" = ["A001"]
 "docs/sphinxext/github_link.py" = ["BLE001"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -168,7 +168,6 @@ ignore = [
   "W605",  # [*] Invalid escape sequence: `\s`
   "E402",  # Module level import not at top of file
   "S607",  # Starting a process with a partial executable path
-  "B028",  # No explicit `stacklevel` keyword argument found
   "DTZ005",  # `datetime.datetime.now()` called without a `tz` argument
   "DTZ007",  # Naive datetime constructed using `datetime.datetime.strptime()` without %z
   "S608",  # Possible SQL injection vector through string-based query construction

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -166,9 +166,7 @@ ignore = [
   "B905",  # `zip()` without an explicit `strict=` parameter
   "S101",  # Use of `assert` detected
   "S607",  # Starting a process with a partial executable path
-  "DTZ005",  # `datetime.datetime.now()` called without a `tz` argument
-  "DTZ007",  # Naive datetime constructed using `datetime.datetime.strptime()` without %z
-  "S608",  # Possible SQL injection vector through string-based query construction
+  "S608",  # ruff interprets informative error message as potential SQL injection vector
   "S108",  # Probable insecure usage of temporary file or directory: "/tmp"
   "S105",
   "S311",  # We are not using random for cryptographic purposes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -165,7 +165,6 @@ ignore = [
   "B017",  # Do not assert blind exception: `Exception`
   "B905",  # `zip()` without an explicit `strict=` parameter
   "S101",  # Use of `assert` detected
-  "PT009",  # Use a regular `assert` instead of unittest-style `assertIn`
   "PT027",  # Use `pytest.raises` instead of unittest-style `assertRaises`
   "W605",  # [*] Invalid escape sequence: `\s`
   "E402",  # Module level import not at top of file

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -172,7 +172,6 @@ ignore = [
   "S202",  # Uses of `tarfile.extractall()`
   "DTZ005",  # `datetime.datetime.now()` called without a `tz` argument
   "DTZ007",  # Naive datetime constructed using `datetime.datetime.strptime()` without %z
-  "A004",  # Import `ConnectionError` is shadowing a Python builtin
   "S608",  # Possible SQL injection vector through string-based query construction
   "S108",  # Probable insecure usage of temporary file or directory: "/tmp"
   "S602",  # `subprocess` call with `shell=True` identified, security issue

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -174,8 +174,6 @@ ignore = [
   "DTZ007",  # Naive datetime constructed using `datetime.datetime.strptime()` without %z
   "S608",  # Possible SQL injection vector through string-based query construction
   "S108",  # Probable insecure usage of temporary file or directory: "/tmp"
-  "S602",  # `subprocess` call with `shell=True` identified, security issue
-  "S113",  # Probable use of `requests` call without timeout
   "S105",
   "S311",  # We are not using random for cryptographic purposes
   "S603",  # subprocess used only for trusted commands (git, pandoc, test runners)

--- a/qsirecon/cli/recon_plot.py
+++ b/qsirecon/cli/recon_plot.py
@@ -131,7 +131,7 @@ def recon_plot():
 
     try:
         display.start()
-    except Exception as exc:
+    except Exception as exc:  # noqa: BLE001
         LOGGER.warning(
             'Unable to start Xvfb!! If you are running this via Apptainer/Singularity '
             'there may be an issue accessing the /tmp directory.\n\n'
@@ -153,7 +153,7 @@ def recon_plot():
             mask_image=opts.mask_file,
             padding=opts.padding,
         )
-    except Exception as exc:
+    except Exception as exc:  # noqa: BLE001
         LOGGER.warning(exc)
         sys.exit(1)
 
@@ -173,7 +173,7 @@ def recon_plot():
                 subtract_iso=opts.subtract_iso,
                 mask=opts.mask_file,
             )
-        except Exception as exc:
+        except Exception as exc:  # noqa: BLE001
             LOGGER.warning(exc)
             sys.exit(1)
 

--- a/qsirecon/cli/version.py
+++ b/qsirecon/cli/version.py
@@ -1,13 +1,34 @@
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
+#
+# Copyright The NiPreps Developers <nipreps@gmail.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# We support and encourage derived works from this project, please read
+# about our expectations at
+#
+#     https://www.nipreps.org/community/licensing/
+#
 """Version CLI helpers."""
 
+from contextlib import suppress
 from datetime import datetime, timezone
 from pathlib import Path
 
 import requests
 
-from .. import __version__
+from qsirecon import __version__
 
 RELEASE_EXPIRY_DAYS = 14
 DATE_FMT = '%Y%m%d'
@@ -20,6 +41,7 @@ def check_latest():
     latest = None
     date = None
     outdated = None
+    now = datetime.now(tz=timezone.utc)
     cachefile = Path.home() / '.cache' / 'qsirecon' / 'latest'
     try:
         cachefile.parent.mkdir(parents=True, exist_ok=True)
@@ -29,23 +51,22 @@ def check_latest():
     if cachefile and cachefile.exists():
         try:
             latest, date = cachefile.read_text().split('|')
-        except Exception:
+        except Exception:  # noqa: S110, BLE001
             pass
         else:
             try:
                 latest = Version(latest)
-                date = datetime.strptime(date, DATE_FMT).replace(tzinfo=timezone.utc)
+                date = datetime.strptime(date, DATE_FMT).astimezone(timezone.utc)
             except (InvalidVersion, ValueError):
                 latest = None
             else:
-                if abs((datetime.now(tz=timezone.utc) - date).days) > RELEASE_EXPIRY_DAYS:
+                if abs((now - date).days) > RELEASE_EXPIRY_DAYS:
                     outdated = True
 
     if latest is None or outdated is True:
-        try:
+        response = None
+        with suppress(Exception):
             response = requests.get(url='https://pypi.org/pypi/qsirecon/json', timeout=1.0)
-        except Exception:
-            response = None
 
         if response and response.status_code == 200:
             versions = [Version(rel) for rel in response.json()['releases'].keys()]
@@ -56,12 +77,8 @@ def check_latest():
             latest = None
 
     if cachefile is not None and latest is not None:
-        try:
-            cachefile.write_text(
-                '|'.join((f'{latest}', datetime.now(tz=timezone.utc).strftime(DATE_FMT)))
-            )
-        except Exception:
-            pass
+        with suppress(OSError):
+            cachefile.write_text(f'{latest}|{now.strftime(DATE_FMT)}')
 
     return latest
 
@@ -70,14 +87,13 @@ def is_flagged():
     """Check whether current version is flagged."""
     # https://raw.githubusercontent.com/pennlinc/qsirecon/main/.versions.json
     flagged = ()
-    try:
+    response = None
+    with suppress(Exception):
         response = requests.get(
             url="""\
 https://raw.githubusercontent.com/pennlinc/qsirecon/main/.versions.json""",
             timeout=1.0,
         )
-    except Exception:
-        response = None
 
     if response and response.status_code == 200:
         flagged = response.json().get('flagged', {}) or {}

--- a/qsirecon/cli/version.py
+++ b/qsirecon/cli/version.py
@@ -2,7 +2,7 @@
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 """Version CLI helpers."""
 
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 
 import requests
@@ -34,11 +34,11 @@ def check_latest():
         else:
             try:
                 latest = Version(latest)
-                date = datetime.strptime(date, DATE_FMT)
+                date = datetime.strptime(date, DATE_FMT).replace(tzinfo=timezone.utc)
             except (InvalidVersion, ValueError):
                 latest = None
             else:
-                if abs((datetime.now() - date).days) > RELEASE_EXPIRY_DAYS:
+                if abs((datetime.now(tz=timezone.utc) - date).days) > RELEASE_EXPIRY_DAYS:
                     outdated = True
 
     if latest is None or outdated is True:
@@ -57,7 +57,9 @@ def check_latest():
 
     if cachefile is not None and latest is not None:
         try:
-            cachefile.write_text('|'.join((f'{latest}', datetime.now().strftime(DATE_FMT))))
+            cachefile.write_text(
+                '|'.join((f'{latest}', datetime.now(tz=timezone.utc).strftime(DATE_FMT)))
+            )
         except Exception:
             pass
 

--- a/qsirecon/config.py
+++ b/qsirecon/config.py
@@ -151,7 +151,7 @@ if not _disable_et:
     # Just get so analytics track one hit
     from contextlib import suppress
 
-    from requests import ConnectionError, ReadTimeout
+    from requests import ConnectionError, ReadTimeout  # noqa: A004
     from requests import get as _get_url
 
     with suppress((ConnectionError, ReadTimeout)):

--- a/qsirecon/interfaces/bids.py
+++ b/qsirecon/interfaces/bids.py
@@ -51,7 +51,7 @@ from qsirecon.data import load as load_data
 
 LOGGER = logging.getLogger('nipype.interface')
 BIDS_NAME = re.compile(
-    '^(.*\/)?(?P<subject_id>sub-[a-zA-Z0-9]+)(_(?P<session_id>ses-[a-zA-Z0-9]+))?'
+    r'^(.*\/)?(?P<subject_id>sub-[a-zA-Z0-9]+)(_(?P<session_id>ses-[a-zA-Z0-9]+))?'
     '(_(?P<task_id>task-[a-zA-Z0-9]+))?(_(?P<acq_id>acq-[a-zA-Z0-9]+))?'
     '(_(?P<space_id>space-[a-zA-Z0-9]+))?'
     '(_(?P<rec_id>rec-[a-zA-Z0-9]+))?(_(?P<run_id>run-[a-zA-Z0-9]+))?'

--- a/qsirecon/interfaces/converters.py
+++ b/qsirecon/interfaces/converters.py
@@ -638,7 +638,8 @@ def fast_load_fibgz(fib_file):
     if zcatter is not None:
         p = subprocess.Popen([zcatter, fib_file], stdout=subprocess.PIPE)
         fh = StringIO(p.communicate()[0])
-        assert p.returncode == 0
+        if p.returncode != 0:
+            raise ValueError(f'Failed to load fib file: {fib_file}')
         return loadmat(fh)
 
     with gzip.open(fib_file, 'r') as f:

--- a/qsirecon/interfaces/converters.py
+++ b/qsirecon/interfaces/converters.py
@@ -402,7 +402,7 @@ def amplitudes_to_fibgz(
     LOGGER.info('Detecting Peaks')
     for odfnum in range(n_odfs):
         dirs, vals, indices = peak_directions(masked_odfs[odfnum], hs)
-        for dirnum, (val, idx) in enumerate(zip(vals, indices)):
+        for dirnum, (val, idx) in enumerate(zip(vals, indices, strict=False)):
             if dirnum == num_fibers:
                 break
             peak_indices[odfnum, dirnum] = idx

--- a/qsirecon/interfaces/denoise.py
+++ b/qsirecon/interfaces/denoise.py
@@ -48,7 +48,9 @@ class SeriesPreprocReport(reporting.ReportCapableInterface):
         pres = []
         posts = []
         differences = []
-        for orig_img, corrected_img in zip(iter_img(original_nii), iter_img(corrected_nii)):
+        for orig_img, corrected_img in zip(
+            iter_img(original_nii), iter_img(corrected_nii), strict=False
+        ):
             orig_data = orig_img.get_fdata()
             corrected_data = corrected_img.get_fdata()
             baseline = orig_data.mean()

--- a/qsirecon/interfaces/dsi_studio.py
+++ b/qsirecon/interfaces/dsi_studio.py
@@ -210,7 +210,8 @@ class DSIStudioGQIReconstruction(CommandLine):
         target = os.path.join(os.getcwd(), srcname) + '*gqi*.fib.gz'
         config.loggers.interface.info(f'search target: {target}')
         results = glob(target)
-        assert len(results) == 1
+        if len(results) != 1:
+            raise ValueError(f'Expected 1 result, got {len(results)}')
         outputs['output_fib'] = results[0]
 
         return outputs

--- a/qsirecon/interfaces/dsi_studio.py
+++ b/qsirecon/interfaces/dsi_studio.py
@@ -557,7 +557,7 @@ def _sanitized_connectivity_matrix(conmat, official_labels):
 
     output = np.zeros((n_atlas_labels, n_atlas_labels))
 
-    for row_index, conn in zip(new_row, connectivity):
+    for row_index, conn in zip(new_row, connectivity, strict=False):
         tmp = np.zeros(n_atlas_labels)
         tmp[in_this_mask] = conn
         output[row_index] = tmp

--- a/qsirecon/interfaces/dsi_studio.py
+++ b/qsirecon/interfaces/dsi_studio.py
@@ -553,7 +553,7 @@ def _sanitized_connectivity_matrix(conmat, official_labels):
         try:
             new_row = np.array([label_to_index[name] for name in matfile_region_ids])
         except KeyError as e:
-            raise KeyError(f"String region name '{e.args[0]}' not found in atlas labels")
+            raise KeyError(f"String region name '{e.args[0]}' not found in atlas labels") from e
 
     output = np.zeros((n_atlas_labels, n_atlas_labels))
 

--- a/qsirecon/interfaces/mrtrix.py
+++ b/qsirecon/interfaces/mrtrix.py
@@ -1150,8 +1150,8 @@ def _rename_connectome(connectome_csv, suffix='_connectome.csv'):
         (image_name,) = [
             part for part in parts if part.startswith('sub_') and part.endswith('recon_wf')
         ]
-    except Exception:
-        raise Exception(f'unable to detect image name from these parts {parts}')
+    except Exception as err:
+        raise ValueError(f'unable to detect image name from these parts {parts}') from err
     image_name = image_name[: -len('_recon_wf')]
     return 'connectome2tck/' + _rebids(image_name) + '_' + conn_name + suffix
 

--- a/qsirecon/interfaces/qc.py
+++ b/qsirecon/interfaces/qc.py
@@ -206,7 +206,7 @@ def embed_tiles_in_json_sprite(tile_list, as_bytes=True, out_file=None):
     i_tile_offsets = tile_size * i_indices
     j_tile_offsets = tile_size * j_indices
 
-    for tile, i_offset, j_offset in zip(tile_list, i_tile_offsets, j_tile_offsets):
+    for tile, i_offset, j_offset in zip(tile_list, i_tile_offsets, j_tile_offsets, strict=False):
         mosaic[i_offset : (i_offset + tile_size), j_offset : (j_offset + tile_size)] = tile
 
     if as_bytes:

--- a/qsirecon/interfaces/recon_scalars.py
+++ b/qsirecon/interfaces/recon_scalars.py
@@ -463,7 +463,8 @@ class ParcellateScalars(SimpleInterface):
         source_suffix = source_suffixes.pop()
 
         atlas_config = self.inputs.atlas_config
-        assert len(atlas_config) == 1, 'Only one atlas config is supported'
+        if len(atlas_config) != 1:
+            raise ValueError('Only one atlas config is supported')
         atlas_name = list(atlas_config.keys())[0]
         atlas_config = atlas_config[atlas_name]
         atlas_file = atlas_config['dwi_resolution_file']

--- a/qsirecon/interfaces/reports.py
+++ b/qsirecon/interfaces/reports.py
@@ -222,7 +222,7 @@ class InteractiveReport(SimpleInterface):
         rms = np.sqrt((translations**2).sum(1))
         fdisp = df['framewise_displacement'].tolist()
         fdisp[0] = None
-        report['eddy_params'] = [[fd_, rms_] for fd_, rms_ in zip(fdisp, rms)]
+        report['eddy_params'] = [[fd_, rms_] for fd_, rms_ in zip(fdisp, rms, strict=False)]
 
         # Get the sampling scheme
         xyz = df[['grad_x', 'grad_y', 'grad_z']].values
@@ -468,7 +468,7 @@ def plot_scalar_map(
         tissue_colors = ['#1b60a5']
         dseg = mask
 
-    tissue_palette = dict(zip(tissue_types, tissue_colors))
+    tissue_palette = dict(zip(tissue_types, tissue_colors, strict=False))
 
     # Extract voxel-wise values for the histogram
     dfs = []
@@ -481,7 +481,12 @@ def plot_scalar_map(
         tissue_type_vals = masking.apply_mask(overlay, mask_img)
         df = pd.DataFrame(
             columns=['Data', 'Tissue Type'],
-            data=list(map(list, zip(*[tissue_type_vals, [tissue_type] * tissue_type_vals.size]))),
+            data=list(
+                map(
+                    list,
+                    zip(*[tissue_type_vals, [tissue_type] * tissue_type_vals.size], strict=False),
+                )
+            ),
         )
         dfs.append(df)
 

--- a/qsirecon/interfaces/scalar_mapping.py
+++ b/qsirecon/interfaces/scalar_mapping.py
@@ -202,7 +202,7 @@ def calculate_mask_stats(
             nz_weighting_vector[np.isnan(nz_voxel_data)] = np.nan
             nz_weighting_vector = nz_weighting_vector / np.nansum(nz_weighting_vector)
             results['masked_weighted_mean'] = np.nansum(nz_voxel_data * nz_weighting_vector)
-        except Exception as exc:
+        except Exception as exc:  # noqa: BLE001
             LOGGER.warn(
                 f'Error calculating weighted mean of {variable_name} in {mask_name}\n{exc}'
             )

--- a/qsirecon/interfaces/scalar_mapping.py
+++ b/qsirecon/interfaces/scalar_mapping.py
@@ -101,7 +101,9 @@ class BundleMapper(ScalarMapper):
         bundle_dfs = []
         tdi_dfs = []
         source_suffix = self.inputs.mapping_metadata.get('qsirecon_suffix', 'QSIRecon')
-        for tck_name, tck_file in zip(self.inputs.bundle_names, self.inputs.tck_files):
+        for tck_name, tck_file in zip(
+            self.inputs.bundle_names, self.inputs.tck_files, strict=False
+        ):
             output_tdi_file = fname_presuffix(
                 tck_file, suffix='_tdi.nii', newpath=runtime.cwd, use_ext=False
             )

--- a/qsirecon/interfaces/utils.py
+++ b/qsirecon/interfaces/utils.py
@@ -171,7 +171,7 @@ def label_convert(original_atlas, output_mif, orig_txt, mrtrix_txt, atlas_labels
         print(f'WARNING: Atlas {atlas_labels_file} has a 0 index. This index will be dropped.')
         atlas_labels_df = atlas_labels_df.loc[atlas_labels_df['index'] != 0]
 
-    index_label_pairs = zip(atlas_labels_df['index'], atlas_labels_df['label'])
+    index_label_pairs = zip(atlas_labels_df['index'], atlas_labels_df['label'], strict=False)
     orig_str = ''
     mrtrix_str = ''
     for i_row, (index, label) in enumerate(index_label_pairs):

--- a/qsirecon/tests/run_local_tests.py
+++ b/qsirecon/tests/run_local_tests.py
@@ -46,18 +46,17 @@ def _get_parser():
 def run_command(command, env=None):
     """Run a given shell command with certain environment variables set.
 
-    Keep this out of the real qsirecon code so that devs don't need to install
-    QSIRecon to run tests.
+    Keep this out of the real XCP-D code so that devs don't need to install XCP-D to run tests.
     """
-    merged_env = os.environ
+    merged_env = os.environ.copy()
     if env:
         merged_env.update(env)
 
     process = subprocess.Popen(
-        command,
+        command.split(),
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
-        shell=True,
+        shell=False,
         env=merged_env,
     )
     while True:

--- a/qsirecon/tests/run_local_tests.py
+++ b/qsirecon/tests/run_local_tests.py
@@ -84,8 +84,8 @@ def run_tests(test_regex, test_mark, check_path):
         try:
             run_command(run_str)
             print(f'Path found: {mounted_code}.')
-        except RuntimeError:
-            raise FileNotFoundError(f'Path not found: {mounted_code}')
+        except RuntimeError as err:
+            raise FileNotFoundError(f'Path not found: {mounted_code}') from err
 
     else:
         run_str = (

--- a/qsirecon/tests/utils.py
+++ b/qsirecon/tests/utils.py
@@ -65,10 +65,10 @@ def download_test_data(dset, data_dir=None):
         if url.endswith('.xz'):
             with lzma.open(BytesIO(req.content)) as f:
                 with tarfile.open(fileobj=f) as t:
-                    t.extractall(out_dir)
+                    t.extractall(out_dir)  # noqa: S202
         elif url.endswith('.gz'):
             with tarfile.open(fileobj=GzipFile(fileobj=BytesIO(req.content))) as t:
-                t.extractall(out_dir)
+                t.extractall(out_dir)  # noqa: S202
         else:
             raise ValueError(f'Unknown file type for {dset} ({url})')
 

--- a/qsirecon/tests/utils.py
+++ b/qsirecon/tests/utils.py
@@ -61,7 +61,7 @@ def download_test_data(dset, data_dir=None):
 
     os.makedirs(out_dir, exist_ok=True)
     url = URLS[dset]
-    with requests.get(url, stream=True) as req:
+    with requests.get(url, stream=True, timeout=10) as req:
         if url.endswith('.xz'):
             with lzma.open(BytesIO(req.content)) as f:
                 with tarfile.open(fileobj=f) as t:

--- a/qsirecon/utils/atlases.py
+++ b/qsirecon/utils/atlases.py
@@ -11,7 +11,7 @@ import logging
 LOGGER = logging.getLogger('nipype.interface')
 
 
-def collect_atlases(datasets, atlases, bids_filters={}):
+def collect_atlases(datasets, atlases, bids_filters=None):
     """Collect atlases from a list of BIDS-Atlas datasets.
 
     Selection of labels files and metadata does not leverage the inheritance principle.

--- a/qsirecon/utils/bids.py
+++ b/qsirecon/utils/bids.py
@@ -142,7 +142,7 @@ def collect_participants(bids_dir, participant_label=None, strict=False, bids_va
         )
         if strict:
             raise exc
-        warnings.warn(exc.msg, BIDSWarning)
+        warnings.warn(exc.msg, BIDSWarning, stacklevel=2)
 
     return found_label
 

--- a/qsirecon/utils/sentry.py
+++ b/qsirecon/utils/sentry.py
@@ -28,10 +28,10 @@ import re
 from nibabel.optpkg import optional_package
 from niworkflows.utils.misc import read_crashfile
 
+from qsirecon import config
+
 sentry_sdk = optional_package('sentry_sdk')[0]
 migas = optional_package('migas')[0]
-
-from .. import config
 
 CHUNK_SIZE = 16384
 # Group common events with pre specified fingerprints

--- a/qsirecon/utils/shm.py
+++ b/qsirecon/utils/shm.py
@@ -504,7 +504,8 @@ def lazy_index(index):
     made index is returned as is.
     """
     index = np.array(index)
-    assert index.ndim == 1
+    if index.ndim != 1:
+        raise ValueError(f'index must be a 1D array, not {index.ndim}')
     if index.dtype.kind == 'b':
         index = index.nonzero()[0]
     if len(index) == 1:
@@ -599,7 +600,11 @@ class SphHarmFit(OdfFit):
         # Index mask
         if self.mask is not None:
             new_mask = self.mask[index]
-            assert new_mask.shape == new_coef.shape[:-1]
+            if new_mask.shape != new_coef.shape[:-1]:
+                raise ValueError(
+                    f'new_mask ({new_mask.shape}) and new_coef ({new_coef.shape[:-1]}) '
+                    'must have the same shape'
+                )
         else:
             new_mask = None
 
@@ -723,8 +728,13 @@ def bootstrap_data_array(data, H, R, permute=None):
 
     if permute is None:
         permute = randint(data.shape[-1], size=data.shape[-1])
-    assert R.shape == H.shape
-    assert len(permute) == R.shape[-1]
+    if not R.shape == H.shape:
+        raise ValueError(f'R ({R.shape}) and H ({H.shape}) must have the same shape')
+    if len(permute) != R.shape[-1]:
+        raise ValueError(
+            f'permute ({len(permute)}) must be the same length as the number of '
+            f'data points: {R.shape[-1]}'
+        )
     R = R[permute]
     data = dot(data, (H + R).T)
     return data

--- a/qsirecon/utils/shm.py
+++ b/qsirecon/utils/shm.py
@@ -884,8 +884,8 @@ def calculate_max_order(n_coeffs):
        \rarrow 2n = L^2 + 3L + 2
        \rarrow L^2 + 3L + 2 - 2n = 0
        \rarrow L^2 + 3L + 2(1-n) = 0
-       \rarrow L_{1,2} = \frac{-3 \pm \sqrt{9 - 8 (1-n)}}{2}
-       \rarrow L{1,2} = \frac{-3 \pm \sqrt{1 + 8n}}{2}
+       \rarrow L_{1,2} = \frac{-3 \\pm \\sqrt{9 - 8 (1-n)}}{2}
+       \rarrow L{1,2} = \frac{-3 \\pm \\sqrt{1 + 8n}}{2}
 
     Finally, the positive value is chosen between the two options.
     """
@@ -934,7 +934,7 @@ def anisotropic_power(sh_coeffs, norm_factor=0.00001, power=2, non_negative=True
     Calculate AP image based on a IxJxKxC SH coefficient matrix based on the
     equation:
     .. math::
-        AP = \sum_{l=2,4,6,...}{\frac{1}{2l+1} \sum_{m=-l}^l{|a_{l,m}|^n}}
+        AP = \\sum_{l=2,4,6,...}{\frac{1}{2l+1} \\sum_{m=-l}^l{|a_{l,m}|^n}}
 
     Where the last dimension, C, is made of a flattened array of $l$x$m$
     coefficients, where $l$ are the SH orders, and $m = 2l+1$,

--- a/qsirecon/utils/testing.py
+++ b/qsirecon/utils/testing.py
@@ -78,7 +78,7 @@ class TestWorkflow(unittest.TestCase):
 
             workflow.disconnect([(from_node, to_node, fields)])
 
-    def assert_inputs_set(self, workflow, additional_inputs={}):
+    def assert_inputs_set(self, workflow, additional_inputs=None):
         """Check that all mandatory inputs of nodes in the workflow (at the first level) are
         already set. Additionally, check that inputs in additional_inputs are set. An input is
         "set" if it is
@@ -87,6 +87,9 @@ class TestWorkflow(unittest.TestCase):
             b) connected to another node's output (e.g. using the workflow.connect method)
         additional_inputs is a dict:
             {'node_name': ['mandatory', 'input', 'fields']}"""
+        if additional_inputs is None:
+            additional_inputs = {}
+
         dummy_node = pe.Node(niu.IdentityInterface(fields=['dummy']), name='DummyNode')
         node_names = [name for name in workflow.list_node_names() if name.count('.') == 0]
         for node_name in set(node_names + list(additional_inputs.keys())):

--- a/qsirecon/utils/testing.py
+++ b/qsirecon/utils/testing.py
@@ -1,14 +1,14 @@
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 """
-Class and utilities for testing the workflows module
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Utilities for testing the workflows module
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 """
 
 import logging
-import unittest
 
+import pytest
 from networkx.exception import NetworkXUnfeasible
 from nipype.interfaces import utility as niu
 from nipype.interfaces.base import isdefined
@@ -17,90 +17,90 @@ from nipype.pipeline import engine as pe
 logging.disable(logging.INFO)  # <- do we really want to do this?
 
 
-class TestWorkflow(unittest.TestCase):
-    """Subclass for test within the workflow module.
-    invoke tests with ``python -m unittest discover test"""
+def assert_is_almost_expected_workflow(
+    expected_name, expected_interfaces, expected_inputs, expected_outputs, actual
+):
+    """Somewhat hacky way to confirm workflows are as expected, but with low confidence."""
+    assert isinstance(actual, pe.Workflow)
+    assert expected_name == actual.name
 
-    def assertIsAlmostExpectedWorkflow(
-        self, expected_name, expected_interfaces, expected_inputs, expected_outputs, actual
-    ):
-        """somewhat hacky way to confirm workflows are as expected, but with low confidence"""
-        self.assertIsInstance(actual, pe.Workflow)
-        self.assertEqual(expected_name, actual.name)
+    actual_nodes = [actual.get_node(name) for name in actual.list_node_names()]
+    actual_ifaces = [node.interface.__class__.__name__ for node in actual_nodes]
 
-        # assert it has the same nodes
-        actual_nodes = [actual.get_node(name) for name in actual.list_node_names()]
-        actual_interfaces = [node.interface.__class__.__name__ for node in actual_nodes]
+    assert_is_subset_of_list(expected_interfaces, actual_ifaces)
+    assert_is_subset_of_list(actual_ifaces, expected_interfaces)
 
-        # assert lists equal
-        self.assertIsSubsetOfList(expected_interfaces, actual_interfaces)
-        self.assertIsSubsetOfList(actual_interfaces, expected_interfaces)
+    actual_inputs, actual_outputs = get_inputs_outputs(actual_nodes)
 
-        # assert expected inputs, outputs exist
-        actual_inputs, actual_outputs = self.get_inputs_outputs(actual_nodes)
+    assert_is_subset_of_list(expected_outputs, actual_outputs)
+    assert_is_subset_of_list(expected_inputs, actual_inputs)
 
-        self.assertIsSubsetOfList(expected_outputs, actual_outputs)
-        self.assertIsSubsetOfList(expected_inputs, actual_inputs)
 
-    def assertIsSubsetOfList(self, expecteds, actuals):
-        for expected in expecteds:
-            self.assertIn(expected, actuals)
+def assert_is_subset_of_list(expecteds, actuals):
+    for expected in expecteds:
+        assert expected in actuals
 
-    def get_inputs_outputs(self, nodes):
-        def get_io_names(pre, ios):
-            return [pre + str(io[0]) for io in ios]
 
-        actual_inputs = []
-        actual_outputs = []
-        node_tuples = [(node.name, node.inputs.items(), node.outputs.items()) for node in nodes]
-        for name, inputs, outputs in node_tuples:
-            pre = str(name) + '.'
-            actual_inputs += get_io_names(pre, inputs)
+def get_inputs_outputs(nodes):
+    def get_io_names(pre, ios):
+        return [pre + str(io[0]) for io in ios]
 
-            pre = pre if pre[0:-1] != 'inputnode' else ''
-            actual_outputs += get_io_names(pre, outputs)
+    actual_inputs = []
+    actual_outputs = []
+    node_tuples = [(node.name, node.inputs.items(), node.outputs.items()) for node in nodes]
+    for name, inputs, outputs in node_tuples:
+        pre = str(name) + '.'
+        actual_inputs += get_io_names(pre, inputs)
 
-        return actual_inputs, actual_outputs
+        pre = pre if pre[0:-1] != 'inputnode' else ''
+        actual_outputs += get_io_names(pre, outputs)
 
-    def assert_circular(self, workflow, circular_connections):
-        """check key paths in workflow by specifying some connections that should induce
-        circular paths, which trips a NetworkX error.
-        circular_connections is a list of tuples:
-            [('from_node_name', 'to_node_name', ('from_node.output_field','to_node.input_field'))]
-        """
+    return actual_inputs, actual_outputs
 
-        for from_node, to_node, fields in circular_connections:
-            from_node = workflow.get_node(from_node)
-            to_node = workflow.get_node(to_node)
-            workflow.connect([(from_node, to_node, fields)])
 
-            self.assertRaises(NetworkXUnfeasible, workflow.write_graph)
+def assert_circular(workflow, circular_connections):
+    """Check key paths in workflow by specifying connections that should induce circular paths.
 
-            workflow.disconnect([(from_node, to_node, fields)])
+    circular_connections is a list of tuples::
 
-    def assert_inputs_set(self, workflow, additional_inputs=None):
-        """Check that all mandatory inputs of nodes in the workflow (at the first level) are
-        already set. Additionally, check that inputs in additional_inputs are set. An input is
-        "set" if it is
-            a) defined explicitly (e.g. in the Interface declaration)
-            OR
-            b) connected to another node's output (e.g. using the workflow.connect method)
-        additional_inputs is a dict:
-            {'node_name': ['mandatory', 'input', 'fields']}"""
-        if additional_inputs is None:
-            additional_inputs = {}
+        [('from_node_name', 'to_node_name', ('from_node.output_field', 'to_node.input_field'))]
+    """
+    for from_node, to_node, fields in circular_connections:
+        from_node = workflow.get_node(from_node)
+        to_node = workflow.get_node(to_node)
+        workflow.connect([(from_node, to_node, fields)])
 
-        dummy_node = pe.Node(niu.IdentityInterface(fields=['dummy']), name='DummyNode')
-        node_names = [name for name in workflow.list_node_names() if name.count('.') == 0]
-        for node_name in set(node_names + list(additional_inputs.keys())):
-            node = workflow.get_node(node_name)
-            mandatory_inputs = list(node.inputs.traits(mandatory=True).keys())
-            other_inputs = additional_inputs[node_name] if node_name in additional_inputs else []
-            for field in set(mandatory_inputs + other_inputs):
-                if isdefined(getattr(node.inputs, field)):
-                    pass
-                else:  # not explicitly defined
-                    # maybe it is connected to an output
-                    with self.assertRaises(Exception):
-                        # throws an error if the input is already connected
-                        workflow.connect([(dummy_node, node, [('dummy', field)])])
+        with pytest.raises(NetworkXUnfeasible):
+            workflow.write_graph()
+
+        workflow.disconnect([(from_node, to_node, fields)])
+
+
+def assert_inputs_set(workflow, additional_inputs=None):
+    """Check that all mandatory inputs of nodes in the workflow (at the first level) are set.
+
+    Additionally, check that inputs in *additional_inputs* are set.  An input is
+    "set" if it is either defined explicitly (e.g. in the Interface declaration)
+    or connected to another node's output (e.g. using ``workflow.connect``).
+
+    Parameters
+    ----------
+    workflow : pe.Workflow
+    additional_inputs : dict, optional
+        ``{'node_name': ['mandatory', 'input', 'fields']}``
+    """
+    if additional_inputs is None:
+        additional_inputs = {}
+
+    dummy_node = pe.Node(niu.IdentityInterface(fields=['dummy']), name='DummyNode')
+    node_names = [name for name in workflow.list_node_names() if name.count('.') == 0]
+    for node_name in set(node_names + list(additional_inputs.keys())):
+        node = workflow.get_node(node_name)
+        mandatory_inputs = list(node.inputs.traits(mandatory=True).keys())
+        other_inputs = additional_inputs[node_name] if node_name in additional_inputs else []
+        for field in set(mandatory_inputs + other_inputs):
+            if isdefined(getattr(node.inputs, field)):
+                pass
+            else:
+                with pytest.raises(Exception):  # noqa: PT011
+                    workflow.connect([(dummy_node, node, [('dummy', field)])])

--- a/qsirecon/utils/testing.py
+++ b/qsirecon/utils/testing.py
@@ -102,5 +102,5 @@ def assert_inputs_set(workflow, additional_inputs=None):
             if isdefined(getattr(node.inputs, field)):
                 pass
             else:
-                with pytest.raises(Exception):  # noqa: PT011
+                with pytest.raises(Exception):  # noqa: PT011, B017
                     workflow.connect([(dummy_node, node, [('dummy', field)])])

--- a/qsirecon/viz/utils.py
+++ b/qsirecon/viz/utils.py
@@ -110,8 +110,8 @@ def slices_from_bbox(mask_data, cuts=3, padding=0):
     stop_coords = B.max(0) + 1
 
     vox_coords = []
-    for start, stop in zip(start_coords, stop_coords):
+    for start, stop in zip(start_coords, stop_coords, strict=False):
         inc = abs(stop - start) / (cuts + 2 * padding + 1)
         slices = [start + (i + 1) * inc for i in range(cuts + 2 * padding)]
         vox_coords.append(slices[padding:-padding])
-    return {k: [int(_v) for _v in v] for k, v in zip(['x', 'y', 'z'], vox_coords)}
+    return {k: [int(_v) for _v in v] for k, v in zip(['x', 'y', 'z'], vox_coords, strict=False)}

--- a/qsirecon/workflows/base.py
+++ b/qsirecon/workflows/base.py
@@ -397,19 +397,19 @@ def _load_recon_spec(spec_name):
     elif spec_name in prepackaged:
         recon_spec = op.join(prepackaged_dir, f'{spec_name}.yaml')
     else:
-        raise Exception(f'{spec_name} is not a file that exists or in {prepackaged}')
+        raise FileNotFoundError(f'{spec_name} is not a file that exists or in {prepackaged}')
 
     if recon_spec.endswith('.json'):
         with open(recon_spec) as f:
             try:
                 spec = json.load(f)
-            except Exception:
-                raise Exception('Unable to read JSON spec. Check the syntax.')
+            except Exception as err:
+                raise ValueError('Unable to read JSON spec. Check the syntax.') from err
     else:
         try:
             spec = load_yaml(recon_spec)
-        except Exception:
-            raise Exception('Unable to read YAML spec. Check the syntax.')
+        except Exception as err:
+            raise ValueError('Unable to read YAML spec. Check the syntax.') from err
 
     if config.execution.sloppy:
         config.loggers.workflow.warning('Forcing reconstruction to use unrealistic parameters')

--- a/qsirecon/workflows/recon/amico.py
+++ b/qsirecon/workflows/recon/amico.py
@@ -29,7 +29,7 @@ def init_amico_noddi_fit_wf(
     inputs_dict,
     name='amico_noddi_recon',
     qsirecon_suffix='',
-    params={},
+    params=None,
 ):
     """Reconstruct NODDI scalars using AMICO.
 
@@ -91,6 +91,9 @@ def init_amico_noddi_fit_wf(
         name='outputnode',
     )
     omp_nthreads = config.nipype.omp_nthreads
+
+    if params is None:
+        params = {}
 
     plot_reports = params.pop('plot_reports', True)
 

--- a/qsirecon/workflows/recon/converters.py
+++ b/qsirecon/workflows/recon/converters.py
@@ -22,7 +22,7 @@ from ...utils.bids import clean_datasinks
 LOGGER = logging.getLogger('nipype.workflow')
 
 
-def init_mif_to_fibgz_wf(inputs_dict, name='mif_to_fibgz', qsirecon_suffix='', params={}):
+def init_mif_to_fibgz_wf(inputs_dict, name='mif_to_fibgz', qsirecon_suffix='', params=None):
     """Converts a MRTrix mif file to DSI Studio fib file.
 
     This workflow uses ``sh2amp`` to sample the FODs on the standard DSI Studio
@@ -52,6 +52,9 @@ def init_mif_to_fibgz_wf(inputs_dict, name='mif_to_fibgz', qsirecon_suffix='', p
     )
     outputnode.inputs.recon_scalars = []
 
+    if params is None:
+        params = {}
+
     convert_to_fib = pe.Node(FODtoFIBGZ(), name='convert_to_fib')
     workflow.connect([
         (inputnode, convert_to_fib, [('fod_sh_mif', 'mif_file')]),
@@ -74,7 +77,7 @@ def init_mif_to_fibgz_wf(inputs_dict, name='mif_to_fibgz', qsirecon_suffix='', p
     return clean_datasinks(workflow, qsirecon_suffix)
 
 
-def init_fibgz_to_mif_wf(name='fibgz_to_mif', qsirecon_suffix='', params={}):
+def init_fibgz_to_mif_wf(name='fibgz_to_mif', qsirecon_suffix='', params=None):
     """Needs Documentation"""
     workflow = Workflow(name=name)
 
@@ -85,6 +88,10 @@ def init_fibgz_to_mif_wf(name='fibgz_to_mif', qsirecon_suffix='', params={}):
         niu.IdentityInterface(fields=['fib_file', 'recon_scalars']), name='outputnode'
     )
     outputnode.inputs.recon_scalars = []
+
+    if params is None:
+        params = {}
+
     convert_to_fib = pe.Node(FODtoFIBGZ(), name='convert_to_fib')
     workflow.connect([
         (inputnode, convert_to_fib, [('mif_file', 'mif_file')]),
@@ -94,7 +101,7 @@ def init_fibgz_to_mif_wf(name='fibgz_to_mif', qsirecon_suffix='', params={}):
     return clean_datasinks(workflow, qsirecon_suffix)
 
 
-def init_fod_fib_wf(inputs_dict, name='fod_fib', qsirecon_suffix='', params={}):
+def init_fod_fib_wf(inputs_dict, name='fod_fib', qsirecon_suffix='', params=None):
     """Converts MRTrix FODs to a DSI Studio fib file for the FOD-AutoTrack method.
 
     Inputs
@@ -132,6 +139,9 @@ def init_fod_fib_wf(inputs_dict, name='fod_fib', qsirecon_suffix='', params={}):
         niu.IdentityInterface(fields=['fibgz', 'fibgz_map', 'recon_scalars']), name='outputnode'
     )
     outputnode.inputs.recon_scalars = []
+
+    if params is None:
+        params = {}
 
     # Convert the FOD sh nifti into a valid fib file
     convert_fod_to_fib = pe.Node(FODtoFIBGZ(), name='convert_fod_to_fib')
@@ -172,7 +182,7 @@ def init_fod_fib_wf(inputs_dict, name='fod_fib', qsirecon_suffix='', params={}):
     return clean_datasinks(workflow, qsirecon_suffix)
 
 
-def init_qsirecon_to_fsl_wf(inputs_dict, name='qsirecon_to_fsl', qsirecon_suffix='', params={}):
+def init_qsirecon_to_fsl_wf(inputs_dict, name='qsirecon_to_fsl', qsirecon_suffix='', params=None):
     """Converts QSIRecon outputs (images, bval, bvec) to fsl standard orientation"""
     workflow = Workflow(name=name)
     workflow.__desc__ = 'The QSIRecon outputs were converted to FSL standard orientation.'
@@ -184,6 +194,9 @@ def init_qsirecon_to_fsl_wf(inputs_dict, name='qsirecon_to_fsl', qsirecon_suffix
     outputnode = pe.Node(niu.IdentityInterface(fields=to_reorient), name='outputnode')
 
     outputnode.inputs.recon_scalars = []
+
+    if params is None:
+        params = {}
 
     convert_dwi_to_fsl = pe.Node(ConformDwi(orientation='LAS'), name='convert_to_fsl')
     convert_mask_to_fsl = pe.Node(ConformDwi(orientation='LAS'), name='convert_mask_to_fsl')

--- a/qsirecon/workflows/recon/dipy.py
+++ b/qsirecon/workflows/recon/dipy.py
@@ -74,7 +74,7 @@ def init_dipy_brainsuite_shore_recon_wf(
     inputs_dict,
     name='dipy_3dshore_recon',
     qsirecon_suffix='',
-    params={},
+    params=None,
 ):
     """Reconstruct EAPs, ODFs, using 3dSHORE (brainsuite-style basis set).
 
@@ -158,6 +158,9 @@ def init_dipy_brainsuite_shore_recon_wf(
         name='outputnode',
     )
     plot_reports = not config.execution.skip_odf_reports
+
+    if params is None:
+        params = {}
 
     # Do we have deltas?
     deltas = (params.get('big_delta', None), params.get('small_delta', None))
@@ -374,7 +377,7 @@ def init_dipy_mapmri_recon_wf(
     inputs_dict,
     name='dipy_mapmri_recon',
     qsirecon_suffix='',
-    params={},
+    params=None,
 ):
     """Reconstruct EAPs, ODFs, using 3dSHORE (brainsuite-style basis set).
 
@@ -480,6 +483,9 @@ def init_dipy_mapmri_recon_wf(
         ),
         name='outputnode',
     )
+
+    if params is None:
+        params = {}
 
     # Do we have deltas?
     deltas, deltas_string = infer_deltas(inputs_dict.get('dwi_metadata', {}), params)
@@ -623,7 +629,7 @@ def init_dipy_mapmri_recon_wf(
     return clean_datasinks(workflow, qsirecon_suffix)
 
 
-def init_dipy_dki_recon_wf(inputs_dict, name='dipy_dki_recon', qsirecon_suffix='', params={}):
+def init_dipy_dki_recon_wf(inputs_dict, name='dipy_dki_recon', qsirecon_suffix='', params=None):
     """Fit DKI.
 
     This workflow corresponds to the "DKI_reconstruction" pipeline action.
@@ -737,6 +743,10 @@ def init_dipy_dki_recon_wf(inputs_dict, name='dipy_dki_recon', qsirecon_suffix='
         ),
         name='outputnode',
     )
+
+    if params is None:
+        params = {}
+
     recon_scalars = pe.Node(
         DIPYDKIReconScalars(qsirecon_suffix=qsirecon_suffix),
         run_without_submitting=True,

--- a/qsirecon/workflows/recon/dsi_studio.py
+++ b/qsirecon/workflows/recon/dsi_studio.py
@@ -44,7 +44,9 @@ from .utils import init_scalar_output_wf
 LOGGER = logging.getLogger('nipype.interface')
 
 
-def init_dsi_studio_recon_wf(inputs_dict, name='dsi_studio_recon', qsirecon_suffix='', params=None):
+def init_dsi_studio_recon_wf(
+    inputs_dict, name='dsi_studio_recon', qsirecon_suffix='', params=None
+):
     """Reconstructs diffusion data using DSI Studio.
 
     This workflow creates a ``.src.gz`` file from the input dwi, bvals and bvecs,

--- a/qsirecon/workflows/recon/dsi_studio.py
+++ b/qsirecon/workflows/recon/dsi_studio.py
@@ -44,7 +44,7 @@ from .utils import init_scalar_output_wf
 LOGGER = logging.getLogger('nipype.interface')
 
 
-def init_dsi_studio_recon_wf(inputs_dict, name='dsi_studio_recon', qsirecon_suffix='', params={}):
+def init_dsi_studio_recon_wf(inputs_dict, name='dsi_studio_recon', qsirecon_suffix='', params=None):
     """Reconstructs diffusion data using DSI Studio.
 
     This workflow creates a ``.src.gz`` file from the input dwi, bvals and bvecs,
@@ -75,6 +75,9 @@ def init_dsi_studio_recon_wf(inputs_dict, name='dsi_studio_recon', qsirecon_suff
     outputnode = pe.Node(
         niu.IdentityInterface(fields=['fibgz', 'recon_scalars']), name='outputnode'
     )
+
+    if params is None:
+        params = {}
 
     outputnode.inputs.recon_scalars = []
     plot_reports = not config.execution.skip_odf_reports
@@ -161,7 +164,7 @@ distance of {romdd} in DSI Studio (version {DSI_STUDIO_VERSION}). """
 def init_dsi_studio_tractography_wf(
     inputs_dict,
     name='dsi_studio_tractography',
-    params={},
+    params=None,
     qsirecon_suffix='',
 ):
     """Calculate streamline-based connectivity matrices using DSI Studio.
@@ -237,6 +240,10 @@ def init_dsi_studio_tractography_wf(
         niu.IdentityInterface(fields=['trk_file', 'fibgz', 'recon_scalars']),
         name='outputnode',
     )
+
+    if params is None:
+        params = {}
+
     outputnode.inputs.recon_scalars = []
     omp_nthreads = config.nipype.omp_nthreads
 
@@ -269,7 +276,7 @@ def init_dsi_studio_tractography_wf(
 
 def init_dsi_studio_autotrack_registration_wf(
     inputs_dict,
-    params={},
+    params=None,
     qsirecon_suffix='',
     name='dsi_studio_autotrack_registration_wf',
 ):
@@ -305,6 +312,10 @@ def init_dsi_studio_autotrack_registration_wf(
         niu.IdentityInterface(fields=['fibgz', 'fibgz_map', 'recon_scalars']),
         name='outputnode',
     )
+
+    if params is None:
+        params = {}
+
     outputnode.inputs.recon_scalars = []
 
     omp_nthreads = config.nipype.omp_nthreads
@@ -331,7 +342,7 @@ def init_dsi_studio_autotrack_registration_wf(
 
 def init_dsi_studio_autotrack_wf(
     inputs_dict,
-    params={},
+    params=None,
     qsirecon_suffix='',
     name='dsi_studio_autotrack_wf',
 ):
@@ -412,6 +423,10 @@ def init_dsi_studio_autotrack_wf(
         niu.IdentityInterface(fields=['tck_files', 'bundle_names', 'recon_scalars']),
         name='outputnode',
     )
+
+    if params is None:
+        params = {}
+
     outputnode.inputs.recon_scalars = []
 
     model_name = params.pop('model', 'gqi')
@@ -520,7 +535,7 @@ def init_dsi_studio_autotrack_wf(
 def init_dsi_studio_connectivity_wf(
     inputs_dict,
     name='dsi_studio_connectivity',
-    params={},
+    params=None,
     qsirecon_suffix='',
 ):
     """Calculate streamline-based connectivity matrices using DSI Studio.
@@ -594,6 +609,10 @@ def init_dsi_studio_connectivity_wf(
     outputnode = pe.Node(
         niu.IdentityInterface(fields=['matfile', 'recon_scalars']), name='outputnode'
     )
+
+    if params is None:
+        params = {}
+
     outputnode.inputs.recon_scalars = []
     omp_nthreads = config.nipype.omp_nthreads
     plot_reports = not config.execution.skip_odf_reports
@@ -651,7 +670,7 @@ def init_dsi_studio_connectivity_wf(
 def init_dsi_studio_export_wf(
     inputs_dict,
     name='dsi_studio_export',
-    params={},
+    params=None,
     qsirecon_suffix='',
 ):
     """Export scalar maps from a DSI Studio fib file into NIfTI files with correct headers.
@@ -686,6 +705,10 @@ def init_dsi_studio_export_wf(
     inputnode = pe.Node(
         niu.IdentityInterface(fields=recon_workflow_input_fields + ['fibgz']), name='inputnode'
     )
+
+    if params is None:
+        params = {}
+
     plot_reports = params.pop('plot_reports', True)  # noqa: F841
     scalar_names = [
         'qa',

--- a/qsirecon/workflows/recon/mrtrix.py
+++ b/qsirecon/workflows/recon/mrtrix.py
@@ -51,7 +51,7 @@ CITATIONS = {
 }
 
 
-def init_mrtrix_csd_recon_wf(inputs_dict, name='mrtrix_recon', qsirecon_suffix='', params={}):
+def init_mrtrix_csd_recon_wf(inputs_dict, name='mrtrix_recon', qsirecon_suffix='', params=None):
     """Create FOD images for WM, GM and CSF.
 
     This workflow uses mrtrix tools to run csd on multishell data. At the end,
@@ -119,6 +119,10 @@ def init_mrtrix_csd_recon_wf(inputs_dict, name='mrtrix_recon', qsirecon_suffix='
         ),
         name='outputnode',
     )
+
+    if params is None:
+        params = {}
+
     outputnode.inputs.recon_scalars = []
     omp_nthreads = config.nipype.omp_nthreads
 
@@ -457,7 +461,7 @@ MRtrix3Tissue (https://3Tissue.github.io), a fork of MRtrix3 (@mrtrix3)."""
     return clean_datasinks(workflow, qsirecon_suffix)
 
 
-def init_global_tractography_wf(inputs_dict, name='mrtrix_recon', qsirecon_suffix='', params={}):
+def init_global_tractography_wf(inputs_dict, name='mrtrix_recon', qsirecon_suffix='', params=None):
     """Run multi-shell, multi-tissue global tractography
 
     This workflow uses mrtrix tools to run csd on multishell data.
@@ -502,6 +506,9 @@ def init_global_tractography_wf(inputs_dict, name='mrtrix_recon', qsirecon_suffi
     )
 
     outputnode.inputs.recon_scalars = []
+
+    if params is None:
+        params = {}
 
     create_mif = pe.Node(MRTrixIngress(), name='create_mif')
 
@@ -580,7 +587,7 @@ def init_global_tractography_wf(inputs_dict, name='mrtrix_recon', qsirecon_suffi
 
 
 def init_mrtrix_tractography_wf(
-    inputs_dict, name='mrtrix_tracking', qsirecon_suffix='', params={}
+    inputs_dict, name='mrtrix_tracking', qsirecon_suffix='', params=None
 ):
     """Run tractography
 
@@ -614,6 +621,9 @@ def init_mrtrix_tractography_wf(
         niu.IdentityInterface(fields=['tck_file', 'sift_weights', 'mu', 'recon_scalars']),
         name='outputnode',
     )
+
+    if params is None:
+        params = {}
 
     outputnode.inputs.recon_scalars = []
     omp_nthreads = config.nipype.omp_nthreads
@@ -708,7 +718,7 @@ def init_mrtrix_tractography_wf(
 def init_mrtrix_connectivity_wf(
     inputs_dict,
     name='mrtrix_connectivity',
-    params={},
+    params=None,
     qsirecon_suffix='',
 ):
     """Runs ``tck2connectome`` on a ``tck`` file.
@@ -739,6 +749,10 @@ def init_mrtrix_connectivity_wf(
         niu.IdentityInterface(fields=['matfile', 'recon_scalars']),
         name='outputnode',
     )
+
+    if params is None:
+        params = {}
+
     outputnode.inputs.recon_scalars = []
 
     calc_connectivity = pe.Node(

--- a/qsirecon/workflows/recon/pyafq.py
+++ b/qsirecon/workflows/recon/pyafq.py
@@ -49,7 +49,7 @@ def _parse_qsirecon_params_dict(params_dict):
     return kwargs
 
 
-def init_pyafq_wf(inputs_dict, name='afq', qsirecon_suffix='', params={}):
+def init_pyafq_wf(inputs_dict, name='afq', qsirecon_suffix='', params=None):
     """Run PyAFQ on some qsirecon outputs
 
     Inputs
@@ -74,6 +74,10 @@ def init_pyafq_wf(inputs_dict, name='afq', qsirecon_suffix='', params={}):
     outputnode = pe.Node(
         niu.IdentityInterface(fields=['afq_dir', 'recon_scalars']), name='outputnode'
     )
+
+    if params is None:
+        params = {}
+
     outputnode.inputs.recon_scalars = []
     omp_nthreads = config.nipype.omp_nthreads
     kwargs = _parse_qsirecon_params_dict(params)

--- a/qsirecon/workflows/recon/scalar_mapping.py
+++ b/qsirecon/workflows/recon/scalar_mapping.py
@@ -32,7 +32,7 @@ from .utils import init_scalar_output_wf
 LOGGER = logging.getLogger('nipype.workflow')
 
 
-def init_scalar_to_bundle_wf(inputs_dict, name='scalar_to_bundle', qsirecon_suffix='', params={}):
+def init_scalar_to_bundle_wf(inputs_dict, name='scalar_to_bundle', qsirecon_suffix='', params=None):
     """Map scalar images to bundles
 
     Inputs
@@ -60,6 +60,9 @@ def init_scalar_to_bundle_wf(inputs_dict, name='scalar_to_bundle', qsirecon_suff
         name='inputnode',
     )
     outputnode = pe.Node(niu.IdentityInterface(fields=['bundle_summary']), name='outputnode')
+
+    if params is None:
+        params = {}
 
     bundle_mapper = pe.Node(BundleMapper(**params), name='bundle_mapper')
     ds_bundle_mapper = pe.Node(
@@ -96,7 +99,7 @@ def init_scalar_to_atlas_wf(
     inputs_dict,
     name='scalar_to_atlas_wf',
     qsirecon_suffix='',
-    params={},
+    params=None,
 ):
     """Parcellate scalar images using atlases.
 
@@ -122,6 +125,9 @@ def init_scalar_to_atlas_wf(
         niu.IdentityInterface(fields=input_fields),
         name='inputnode',
     )
+
+    if params is None:
+        params = {}
 
     split_atlas_configs = pe.Node(
         SplitAtlasConfigs(),
@@ -173,7 +179,7 @@ def init_scalar_to_template_wf(
     inputs_dict,
     name='scalar_to_template',
     qsirecon_suffix='',
-    params={},
+    params=None,
 ):
     """Maps scalar data to a volumetric template
 
@@ -211,6 +217,9 @@ def init_scalar_to_template_wf(
         name='outputnode',
     )
 
+    if params is None:
+        params = {}
+
     template_mapper = pe.Node(
         TemplateMapper(template_space=inputs_dict['template_output_space'], **params),
         name='template_mapper',
@@ -243,7 +252,10 @@ def init_scalar_to_surface_wf(
     inputs_dict,
     name='scalar_to_surface',
     qsirecon_suffix='',
-    params={},
+    params=None,
 ):
     """Maps scalar data to a surface."""
+    if params is None:
+        params = {}
+
     raise NotImplementedError()

--- a/qsirecon/workflows/recon/scalar_mapping.py
+++ b/qsirecon/workflows/recon/scalar_mapping.py
@@ -32,7 +32,9 @@ from .utils import init_scalar_output_wf
 LOGGER = logging.getLogger('nipype.workflow')
 
 
-def init_scalar_to_bundle_wf(inputs_dict, name='scalar_to_bundle', qsirecon_suffix='', params=None):
+def init_scalar_to_bundle_wf(
+    inputs_dict, name='scalar_to_bundle', qsirecon_suffix='', params=None
+):
     """Map scalar images to bundles
 
     Inputs

--- a/qsirecon/workflows/recon/steinhardt.py
+++ b/qsirecon/workflows/recon/steinhardt.py
@@ -13,7 +13,7 @@ from ...utils.bids import clean_datasinks
 LOGGER = logging.getLogger('nipype.interface')
 
 
-def init_steinhardt_order_param_wf(inputs_dict, name='sop_recon', qsirecon_suffix='', params={}):
+def init_steinhardt_order_param_wf(inputs_dict, name='sop_recon', qsirecon_suffix='', params=None):
     """Compute Steinhardt order parameters based on ODFs or FODs
 
     Inputs
@@ -40,6 +40,9 @@ def init_steinhardt_order_param_wf(inputs_dict, name='sop_recon', qsirecon_suffi
         niu.IdentityInterface(fields=['q2_file', 'q4_file', 'q6_file', 'q8_file']),
         name='outputnode',
     )
+
+    if params is None:
+        params = {}
 
     sop_order = params.get('order', 8)
     sh_mif_to_nifti = pe.Node(

--- a/qsirecon/workflows/recon/tortoise.py
+++ b/qsirecon/workflows/recon/tortoise.py
@@ -46,7 +46,9 @@ CITATIONS = {
 }
 
 
-def init_tortoise_estimator_wf(inputs_dict, name='tortoise_recon', qsirecon_suffix='', params=None):
+def init_tortoise_estimator_wf(
+    inputs_dict, name='tortoise_recon', qsirecon_suffix='', params=None
+):
     """Run estimators from TORTOISE.
 
     This workflow may run ``EstimateTensor`` and/or ``EstimateMAPMRI``

--- a/qsirecon/workflows/recon/tortoise.py
+++ b/qsirecon/workflows/recon/tortoise.py
@@ -46,7 +46,7 @@ CITATIONS = {
 }
 
 
-def init_tortoise_estimator_wf(inputs_dict, name='tortoise_recon', qsirecon_suffix='', params={}):
+def init_tortoise_estimator_wf(inputs_dict, name='tortoise_recon', qsirecon_suffix='', params=None):
     """Run estimators from TORTOISE.
 
     This workflow may run ``EstimateTensor`` and/or ``EstimateMAPMRI``
@@ -104,6 +104,9 @@ def init_tortoise_estimator_wf(inputs_dict, name='tortoise_recon', qsirecon_suff
         ),
         name='outputnode',
     )
+
+    if params is None:
+        params = {}
 
     recon_scalars = pe.Node(
         TORTOISEReconScalars(qsirecon_suffix=qsirecon_suffix),

--- a/qsirecon/workflows/recon/utils.py
+++ b/qsirecon/workflows/recon/utils.py
@@ -22,7 +22,7 @@ from ...interfaces.utils import TestReportPlot, WriteSidecar
 from ...utils.bids import clean_datasinks
 
 
-def init_conform_dwi_wf(inputs_dict, name='conform_dwi', qsirecon_suffix='', params={}):
+def init_conform_dwi_wf(inputs_dict, name='conform_dwi', qsirecon_suffix='', params=None):
     """If data were preprocessed elsewhere, ensure the gradients and images
     conform to LPS+ before running other parts of the pipeline."""
     workflow = Workflow(name=name)
@@ -35,6 +35,9 @@ def init_conform_dwi_wf(inputs_dict, name='conform_dwi', qsirecon_suffix='', par
         niu.IdentityInterface(fields=['dwi_file', 'bval_file', 'bvec_file', 'b_file']),
         name='outputnode',
     )
+
+    if params is None:
+        params = {}
 
     conform = pe.Node(ConformDwi(), name='conform_dwi')
     grad_table = pe.Node(MRTrixGradientTable(), name='grad_table')
@@ -58,7 +61,7 @@ def init_discard_repeated_samples_wf(
     inputs_dict,
     name='discard_repeats',
     qsirecon_suffix='',
-    params={},
+    params=None,
 ):
     """Remove a sample if a similar direction/gradient has already been sampled."""
     workflow = Workflow(name=name)
@@ -87,6 +90,9 @@ def init_discard_repeated_samples_wf(
         name='outputnode',
     )
 
+    if params is None:
+        params = {}
+
     discard_repeats = pe.Node(RemoveDuplicates(**params), name='discard_repeats')
     workflow.connect([
         (inputnode, discard_repeats, [
@@ -110,7 +116,7 @@ def init_gradient_select_wf(
     inputs_dict,
     name='gradient_select_wf',
     qsirecon_suffix='',
-    params={},
+    params=None,
 ):
     """Remove a sample if a similar direction/gradient has already been sampled."""
     workflow = Workflow(name=name)
@@ -132,6 +138,9 @@ def init_gradient_select_wf(
         ),
         name='outputnode',
     )
+
+    if params is None:
+        params = {}
 
     gradient_select = pe.Node(GradientSelect(**params), name='gradient_select')
     workflow.connect([
@@ -221,7 +230,7 @@ def init_scalar_output_wf(
     return workflow
 
 
-def init_test_wf(inputs_dict, name='test_wf', qsirecon_suffix='test', params={}):
+def init_test_wf(inputs_dict, name='test_wf', qsirecon_suffix='test', params=None):
     """A workflow for testing how derivatives will be saved."""
     workflow = Workflow(name=name)
     workflow.__desc__ = (
@@ -234,6 +243,10 @@ def init_test_wf(inputs_dict, name='test_wf', qsirecon_suffix='test', params={})
     outputnode = pe.Node(
         niu.IdentityInterface(fields=['fibgz', 'recon_scalars']), name='outputnode'
     )
+
+    if params is None:
+        params = {}
+
     outputnode.inputs.recon_scalars = []
 
     write_metadata = pe.Node(WriteSidecar(metadata=inputs_dict), name='write_metadata')


### PR DESCRIPTION
Closes none.

## Changes proposed in this pull request

- Stop ignoring the following:
    - "B006",  # Do not use mutable data structures for argument defaults (keep in ignore)
    - "S110",  # `try`-`except`-`pass` detected
    - "B904",  # Within an `except` clause, raise exceptions
    - "BLE001",  # Do not catch blind exceptions
    - "B017",  # Do not assert blind exception: `Exception`
    - "B905",  # `zip()` without an explicit `strict=` parameter
    - "S101",  # Use of `assert` detected
    - "PT009",  # Use a regular `assert` instead of unittest-style `assertIn`
    - "PT027",  # Use `pytest.raises` instead of unittest-style `assertRaises`
    - "W605",  # [*] Invalid escape sequence: `\s`
    - "E402",  # Module level import not at top of file
    - "B028",  # No explicit `stacklevel` keyword argument found
    - "S202",  # Uses of `tarfile.extractall()`
    - "DTZ005",  # `datetime.datetime.now()` called without a `tz` argument
    - "DTZ007",  # Naive datetime constructed using `datetime.datetime.strptime()` without %z
    - "A004",  # Import `ConnectionError` is shadowing a Python builtin
    - "S602",  # `subprocess` call with `shell=True` identified, security issue
    - "S113",  # Probable use of `requests` call without timeout