### PR TITLE
Prepare for 26.0.0 release

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -175,5 +175,5 @@ keywords:
   - BIDS
   - BIDS-App
 license: BSD-3-Clause
-version: 1.2.0
-date-released: '2026-02-18'
+version: 26.0.0
+date-released: '2026-04-20'

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -1,6 +1,32 @@
 # What's New
 
-## 1.2.0
+
+## 26.0.0 (April 20, 2026)
+
+### 🛠 Breaking Changes
+
+* Bring packaging in line with NiPreps and adopt BIDS atlas organization by @tsalo in https://github.com/PennLINC/qsirecon/pull/367
+
+### 🐛 Bug Fixes
+
+* Allow schemes to be classified as "unknown" by @tsalo in https://github.com/PennLINC/qsirecon/pull/364
+* Replace np.complex with complex by @tsalo in https://github.com/PennLINC/qsirecon/pull/372
+* Change shutil.copy to shutil.copyfile by @tsalo in https://github.com/PennLINC/qsirecon/pull/373
+* Make `--recon-spec` a required argument by @tsalo in https://github.com/PennLINC/qsirecon/pull/375
+
+### Other Changes
+
+* Migrate from flake8 + black + isort to ruff by @tsalo in https://github.com/PennLINC/qsirecon/pull/351
+* Address easy style issues by @tsalo in https://github.com/PennLINC/qsirecon/pull/352
+* Fix version string issue by @tsalo in https://github.com/PennLINC/qsirecon/pull/355
+* Add tox, pre-commit config, and dependabot by @tsalo in https://github.com/PennLINC/qsirecon/pull/353
+* Address Sphinx build issues by @tsalo in https://github.com/PennLINC/qsirecon/pull/366
+* Remove undefined `FSFAST_HOME` variable by @tsalo in https://github.com/PennLINC/qsirecon/pull/376
+
+**Full Changelog**: https://github.com/PennLINC/qsirecon/compare/1.2.0...26.0.0
+
+
+## 1.2.0 (February 18, 2026)
 
 ### 🛠 Breaking Changes
 
@@ -62,7 +88,7 @@
 **Full Changelog**: https://github.com/PennLINC/qsirecon/compare/1.1.1...1.2.0
 
 
-## 1.1.1
+## 1.1.1 (August 19, 2025)
 
 This release fixes a major bug in QSIRecon's handling of multi-session and multi-run datasets.
 When processing multiple sessions or runs in a single QSIRecon call, the reconstruction workflow was being modified in place,
@@ -100,7 +126,7 @@ The built-in workflows should be largely unaffected.
 **Full Changelog**: https://github.com/PennLINC/qsirecon/compare/1.1.0...1.1.1
 
 
-## 1.1.0
+## 1.1.0 (April 14, 2025)
 
 ### 🎉 Exciting New Features
 
@@ -118,7 +144,7 @@ The built-in workflows should be largely unaffected.
 
 **Full Changelog**: https://github.com/PennLINC/qsirecon/compare/1.0.1...1.1.0
 
-## 1.0.1
+## 1.0.1 (March 12, 2025)
 
 ### 🎉 Exciting New Features
 
@@ -139,7 +165,7 @@ The built-in workflows should be largely unaffected.
 
 **Full Changelog**: https://github.com/PennLINC/qsirecon/compare/1.0.0...1.0.1
 
-## 1.0.0
+## 1.0.0 (March 11, 2025)
 
 ### 🛠 Breaking Changes
 

--- a/pixi.lock
+++ b/pixi.lock
@@ -6,8 +6,6 @@ environments:
     - url: https://conda.anaconda.org/conda-forge/
     indexes:
     - https://pypi.org/simple
-    options:
-      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-7_kmp_llvm.conda
@@ -371,8 +369,6 @@ environments:
     - url: https://conda.anaconda.org/conda-forge/
     indexes:
     - https://pypi.org/simple
-    options:
-      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-7_kmp_llvm.conda
@@ -762,8 +758,6 @@ environments:
     - url: https://conda.anaconda.org/conda-forge/
     indexes:
     - https://pypi.org/simple
-    options:
-      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-7_kmp_llvm.conda
@@ -5798,8 +5792,87 @@ packages:
   timestamp: 1770223379599
 - pypi: ./
   name: qsirecon
-  version: 1.2.1.dev44+g595f78582.d20260410
-  sha256: 8500f6bec6443c22b373eea2ad8a10185c0cfed18f22993c93618bf14597039c
+  version: 26.0.0.dev16+g5f456a40b
+  sha256: 020648c3cba8cf203319db8f522a43cd0c88a8e9051edeebce8025fd7ae85905
+  requires_dist:
+  - dipy>=1.10.0,<1.11.0
+  - dmri-amico==2.0.3
+  - filelock
+  - fury
+  - importlib-resources ; python_full_version < '3.11'
+  - indexed-gzip<=1.8.7
+  - ingress2qsirecon~=0.3
+  - jinja2<3.1
+  - networkx~=2.8.8
+  - nibabel<=6.0.0
+  - nilearn==0.10.1
+  - nipype==1.9.1
+  - nireports>=24.0.3
+  - niworkflows>=1.13,<1.14
+  - packaging
+  - psutil<=5.9.8
+  - pyafq==2.0
+  - pybids
+  - pyyaml
+  - scikit-image
+  - scikit-learn<=1.4.0
+  - seaborn
+  - sentry-sdk
+  - simpleitk
+  - svgutils<=0.3.4
+  - transforms3d
+  - vtk
+  - xvfbwrapper
+  - coverage ; extra == 'all'
+  - doctest-ignore-unicode ; extra == 'all'
+  - fuzzywuzzy ; extra == 'all'
+  - lxml-html-clean ; extra == 'all'
+  - nbsphinx ; extra == 'all'
+  - pre-commit ; extra == 'all'
+  - pydot>=1.2.3 ; extra == 'all'
+  - pydotplus ; extra == 'all'
+  - pytest ; extra == 'all'
+  - pytest-cov ; extra == 'all'
+  - pytest-env ; extra == 'all'
+  - python-levenshtein ; extra == 'all'
+  - recommonmark ; extra == 'all'
+  - ruff~=0.15.0 ; extra == 'all'
+  - sphinx-argparse ; extra == 'all'
+  - sphinx-design ; extra == 'all'
+  - sphinx-markdown-tables ; extra == 'all'
+  - sphinx-rtd-theme ; extra == 'all'
+  - sphinx>=4.2.0 ; extra == 'all'
+  - sphinxcontrib-apidoc ; extra == 'all'
+  - sphinxcontrib-bibtex ; extra == 'all'
+  - tox ; extra == 'all'
+  - pre-commit ; extra == 'dev'
+  - ruff~=0.15.0 ; extra == 'dev'
+  - tox ; extra == 'dev'
+  - doctest-ignore-unicode ; extra == 'doc'
+  - lxml-html-clean ; extra == 'doc'
+  - nbsphinx ; extra == 'doc'
+  - pydot>=1.2.3 ; extra == 'doc'
+  - pydotplus ; extra == 'doc'
+  - recommonmark ; extra == 'doc'
+  - sphinx-argparse ; extra == 'doc'
+  - sphinx-design ; extra == 'doc'
+  - sphinx-markdown-tables ; extra == 'doc'
+  - sphinx-rtd-theme ; extra == 'doc'
+  - sphinx>=4.2.0 ; extra == 'doc'
+  - sphinxcontrib-apidoc ; extra == 'doc'
+  - sphinxcontrib-bibtex ; extra == 'doc'
+  - fuzzywuzzy ; extra == 'maint'
+  - python-levenshtein ; extra == 'maint'
+  - coverage ; extra == 'tests'
+  - pytest ; extra == 'tests'
+  - pytest-cov ; extra == 'tests'
+  - pytest-env ; extra == 'tests'
+  requires_python: '>=3.10'
+  editable: true
+- pypi: ./
+  name: qsirecon
+  version: 26.0.0.dev16+g5f456a40b
+  sha256: 020648c3cba8cf203319db8f522a43cd0c88a8e9051edeebce8025fd7ae85905
   requires_dist:
   - dipy>=1.10.0,<1.11.0
   - dmri-amico==2.0.3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,12 +3,12 @@ requires = ["hatchling", "hatch-vcs", "nipreps-versions", "cython", "numpy", "se
 build-backend = "hatchling.build"
 
 [project]
-name = "qsirecon"
-description = "qsirecon builds workflows for reconstructing q-space images"
+name = "QSIRecon"
+description = "QSIRecon builds workflows for reconstructing q-space images"
 readme = "long_description.rst"
 authors = [{name = "The PennLINC developers"}]
 classifiers = [
-    "Development Status :: 3 - Alpha",
+    "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Science/Research",
     "Topic :: Scientific/Engineering :: Image Recognition",
     "License :: OSI Approved :: BSD License",
@@ -116,7 +116,7 @@ exclude = [
 
 [tool.hatch.version]
 source = "vcs"
-# raw-options = { version_scheme = "nipreps-calver" }
+raw-options = { version_scheme = "nipreps-calver" }
 
 [tool.hatch.build.hooks.vcs]
 version-file = "qsirecon/_version.py"


### PR DESCRIPTION
Closes none.

## Changes proposed in this pull request

- Update development status from "alpha" to "production".
- Switch to NiPreps calendar versioning.
- Set version in CITATION.cff to 26.0.0.