### PR TITLE
Add DIPY_HOME environment variable to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,6 +45,7 @@ RUN python fetch_templates.py
 FROM ${BASE_IMAGE} AS base
 WORKDIR /home/qsirecon
 ENV HOME="/home/qsirecon"
+ENV DIPY_HOME="/home/qsirecon/.dipy"
 
 COPY --link --from=templates /templateflow /home/qsirecon/.cache/templateflow
 RUN chmod -R go=u $HOME


### PR DESCRIPTION
Closes #381.

## Changes proposed in this pull request

- Set DIPY_HOME environment variable within Dockerfile so amico looks for downloaded files in that location instead of the home directory.